### PR TITLE
Repository update for ch.protonmail.android.json

### DIFF
--- a/data/apps/ch.protonmail.android.json
+++ b/data/apps/ch.protonmail.android.json
@@ -2,7 +2,7 @@
     "configs": [
         {
             "id": "ch.protonmail.android",
-            "url": "https://github.com/ProtonMail/proton-mail-android",
+            "url": "https://github.com/ProtonMail/android-mail",
             "author": "ProtonMail",
             "name": "Proton Mail",
             "additionalSettings": "{\"includePrereleases\":false,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"\",\"filterReleaseNotesByRegEx\":\"\",\"verifyLatestTag\":false,\"dontSortReleasesList\":false,\"useLatestAssetDateAsReleaseDate\":false,\"trackOnly\":false,\"versionExtractionRegEx\":\"\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"\",\"shizukuPretendToBeGooglePlay\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\"}"


### PR DESCRIPTION
Protonmail switched their repository from https://github.com/ProtonMail/proton-mail-android to https://github.com/ProtonMail/android-mail 