### PR TITLE
Specify fonts (& editorconfig indent style)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,8 @@ root = true
 trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
+indent_style = space
+indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false

--- a/data/style.css
+++ b/data/style.css
@@ -1,0 +1,5 @@
+:root {
+    --bulma-family-primary: "Liberation Sans", "Arimo", "Arial", sans-serif;
+    --bulma-family-secondary: "Liberation Sans", "Arimo", "Arial", sans-serif;
+    --bulma-family-code: "Liberation Mono", "Cousine", "Courier New", monospace;
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
+    <link rel="stylesheet" href="/data/style.css">
     <script src="script.js?v=20240113"></script>
     <title>Obtainium Apps</title>
     <link rel="icon" href="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/icon_small.png">

--- a/redirect.html
+++ b/redirect.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Obtainium Redirect</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/data/style.css" rel="stylesheet" >
     <link rel="icon" href="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/icon_small.png">
     <style>
         body {


### PR DESCRIPTION
Closes: #67 

This doesn't seem to actually fix warnings about fonts appearing in Firefox console and thus I am not certain if this is worth it.

However the editorconfig change would stop at least my editors from throwing in tabs while everything around is 4 spaces and if there was a desire for custimizing the css or Bulma variables in the future, this PR would contain the groundwork for that. 