### PR TITLE
Update Bitwarden URL

### DIFF
--- a/data/apps/com.x8bit.bitwarden.json
+++ b/data/apps/com.x8bit.bitwarden.json
@@ -2,7 +2,7 @@
     "configs": [
         {
             "id": "com.x8bit.bitwarden",
-            "url": "https://github.com/bitwarden/mobile",
+            "url": "https://github.com/bitwarden/android",
             "author": "bitwarden",
             "name": "Bitwarden",
             "preferredApkIndex": 0,


### PR DESCRIPTION
https://github.com/bitwarden/mobile is marked as retired. Switch to https://github.com/bitwarden/android for releases