### PR TITLE
Add Ice Box track-only configuration

### DIFF
--- a/data/apps/com.arlosoft.macrodroid.json
+++ b/data/apps/com.arlosoft.macrodroid.json
@@ -4,7 +4,7 @@
             "id": "com.arlosoft.macrodroid",
             "url": "https://www.macrodroidforum.com/index.php?forums/beta-releases.24/",
             "author": "ArloSoft",
-            "name": "MacroDroid",
+            "name": "MacroDroid (Beta)",
             "additionalSettings": "{\"about\":\"Make your phone truly smart with the number one automation app on Android\",\"apkFilterRegEx\":\"arm64\\\\.apk$\",\"appName\":\"MacroDroid\",\"autoApkFilterByArch\":false,\"intermediateLink\":[{\"customLinkFilterRegex\":\"^V[0-9]+\\\\.[0-9]+$\",\"filterByLinkText\":true,\"reverseSort\":false,\"skipSort\":false,\"sortByLastLinkSegment\":true},{\"customLinkFilterRegex\":\"\\\\/index\\\\.php\\\\?threads\\\\/v[0-9]+\\\\-[0-9]+\\\\.[0-9]+\\\\/(?:page\\\\-[0-9]+)?$\",\"filterByLinkText\":false,\"reverseSort\":false,\"skipSort\":false,\"sortByLastLinkSegment\":false}],\"invertAPKFilter\":false,\"matchGroupToUse\":\"$1.$2.$3\",\"reverseSort\":false,\"skipSort\":false,\"sortByLastLinkSegment\":true,\"trackOnly\":false,\"useVersionCodeAsOSVersion\":false,\"versionDetection\":true,\"versionExtractWholePage\":false,\"versionExtractionRegEx\":\"(?<=\\\\/macrodroid_v)([0-9]+)_([0-9]+)_([0-9]+)(?=_beta\\\\-[^\\\\/]+\\\\.apk$)\"}",
             "overrideSource": "HTML",
             "altLabel": "arm64 v8a"
@@ -13,7 +13,7 @@
             "id": "com.arlosoft.macrodroid",
             "url": "https://www.macrodroidforum.com/index.php?forums/beta-releases.24/",
             "author": "ArloSoft",
-            "name": "MacroDroid",
+            "name": "MacroDroid (Beta)",
             "additionalSettings": "{\"about\":\"Make your phone truly smart with the number one automation app on Android\",\"apkFilterRegEx\":\"universal\\\\.apk$\",\"appName\":\"MacroDroid\",\"autoApkFilterByArch\":false,\"intermediateLink\":[{\"customLinkFilterRegex\":\"^V[0-9]+\\\\.[0-9]+$\",\"filterByLinkText\":true,\"reverseSort\":false,\"skipSort\":false,\"sortByLastLinkSegment\":true},{\"customLinkFilterRegex\":\"\\\\/index\\\\.php\\\\?threads\\\\/v[0-9]+\\\\-[0-9]+\\\\.[0-9]+\\\\/(?:page\\\\-[0-9]+)?$\",\"filterByLinkText\":false,\"reverseSort\":false,\"skipSort\":false,\"sortByLastLinkSegment\":false}],\"invertAPKFilter\":false,\"matchGroupToUse\":\"$1.$2.$3\",\"reverseSort\":false,\"skipSort\":false,\"sortByLastLinkSegment\":true,\"trackOnly\":false,\"useVersionCodeAsOSVersion\":false,\"versionDetection\":true,\"versionExtractWholePage\":false,\"versionExtractionRegEx\":\"(?<=\\\\/macrodroid_v)([0-9]+)_([0-9]+)_([0-9]+)(?=_beta\\\\-[^\\\\/]+\\\\.apk$)\"}",
             "overrideSource": "HTML",
             "altLabel": "universal"

--- a/data/apps/com.catchingnow.icebox.json
+++ b/data/apps/com.catchingnow.icebox.json
@@ -1,0 +1,21 @@
+{
+    "configs": [
+        {
+            "id": "com.catchingnow.icebox",
+            "url": "https://coolapk.com/apk/com.catchingnow.icebox",
+            "author": "何若昕",
+            "name": "Ice Box",
+            "additionalSettings": "{\"about\":\"Freeze and hide apps rarely used, they won't be able to steal your battery or cellular data in background.\",\"appName\":\"Ice Box\",\"customLinkFilterRegex\":\"^https\\\\:\\\\/\\\\/dl\\\\.coolapk\\\\.com\\\\/down\\\\?pn\\\\=com\\\\.catchingnow\\\\.icebox(?:[&#].*)?$\",\"filterByLinkText\":false,\"matchGroupToUse\":\"$1\",\"reverseSort\":true,\"skipSort\":true,\"trackOnly\":true,\"useVersionCodeAsOSVersion\":false,\"versionDetection\":false,\"versionExtractWholePage\":true,\"versionExtractionRegEx\":\"\\\\<span(?:\\\\s|(?:\\\\\\\\n))+class\\\\=\\\"list_app_info\\\"\\\\>(?:\\\\s|(?:\\\\\\\\n))+([^<]+)(?:\\\\s|(?:\\\\\\\\n))*\\\\<\\\\/span\\\\>\"}",
+            "overrideSource": "HTML",
+            "altLabel": "track only"
+        }
+    ],
+    "icon": "https://www.catchingnow.com/pic/icebox.png",
+    "categories": [
+        "utilities"
+    ],
+    "description": {
+        "en": "Freeze and hide apps rarely used, they won't be able to steal your battery or cellular data in background.",
+        "zh": "将不常用的应用统统冻起来，防止后台运行，有效的防止它们在后台偷电偷流量。"
+    }
+}

--- a/data/apps/com.catchingnow.icebox.json
+++ b/data/apps/com.catchingnow.icebox.json
@@ -5,7 +5,7 @@
             "url": "https://coolapk.com/apk/com.catchingnow.icebox",
             "author": "何若昕",
             "name": "Ice Box",
-            "additionalSettings": "{\"about\":\"Freeze and hide apps rarely used, they won't be able to steal your battery or cellular data in background.\",\"appName\":\"Ice Box\",\"customLinkFilterRegex\":\"^https\\\\:\\\\/\\\\/dl\\\\.coolapk\\\\.com\\\\/down\\\\?pn\\\\=com\\\\.catchingnow\\\\.icebox(?:[&#].*)?$\",\"filterByLinkText\":false,\"matchGroupToUse\":\"$1\",\"reverseSort\":true,\"skipSort\":true,\"trackOnly\":true,\"useVersionCodeAsOSVersion\":false,\"versionDetection\":false,\"versionExtractWholePage\":true,\"versionExtractionRegEx\":\"\\\\<span(?:\\\\s|(?:\\\\\\\\n))+class\\\\=\\\"list_app_info\\\"\\\\>(?:\\\\s|(?:\\\\\\\\n))+([^<]+)(?:\\\\s|(?:\\\\\\\\n))*\\\\<\\\\/span\\\\>\"}",
+            "additionalSettings": "{\"about\":\"Freeze and hide apps rarely used, they won't be able to steal your battery or cellular data in background.\",\"appName\":\"Ice Box\",\"customLinkFilterRegex\":\"^https\\\\:\\\\/\\\\/dl\\\\.coolapk\\\\.com\\\\/down\\\\?pn\\\\=com\\\\.catchingnow\\\\.icebox(?:[&#].*)?$\",\"filterByLinkText\":false,\"reverseSort\":true,\"skipSort\":true,\"trackOnly\":true,\"useVersionCodeAsOSVersion\":false,\"versionDetection\":false,\"versionExtractWholePage\":true,\"versionExtractionRegEx\":\"(?<=\\\\<span(?:\\\\s|(?:\\\\\\\\n))+class\\\\=\\\"list_app_info\\\"\\\\>(?:\\\\s|(?:\\\\\\\\n))+)(?!\\\\\\\\n)[^<\\\\s](?:[^<]*[^<\\\\s])?(?<!\\\\\\\\n)(?=(?:\\\\s|(?:\\\\\\\\n))*\\\\<\\\\/span\\\\>)\"}",
             "overrideSource": "HTML",
             "altLabel": "track only"
         }


### PR DESCRIPTION
- Page: https://coolapk.com/apk/com.catchingnow.icebox

Ice Box uses CoolApk as one of several official distribution channels. CoolApk is a popular app store/marketplace in China, where Google services aren't easily accessible.

Relates to #145

---

### About track-only

CoolApk app details page contains static download links, in the format
```
https://dl.coolapk.com/down?pn=com.catchingnow.icebox&id=MjAyMTk&h=<alphanumerics>&from=click
```
- `pn` is the package name of Ice Box
- `id` is probably the ID assigned to the app used internally by CoolApk
- `h` is a string of alphabet letters and numbers

The `h` parameter is generated server-side, corresponding to a session identified by cookie `SESSID`. If the session cookie and the URL parameter are correct, the server will send an APK file, otherwise it'll send an error page with status code 404.

Because Obtainium doesn't use sessions, it loads the page `https://coolapk.com/apk/com.catchingnow.icebox` and is able to extract a download link, but the download link can't be used to get the APK file when the user presses Install/Update button.

---

If Obtainium is to support downloading from CoolApk and other sites functioning in similar ways, it needs some (likely non-trivial) changes:

- Consider `Set-Cookie` response header, for the cookies, their domains, paths, and expiry times
- Use the same cookie jar during one round of page scraping and APK download (if the user choose to install or update before the next round of update check happens). `Cookie` request header needs to be included