### PR TITLE
Revert "Update Bitwarden URL"

### DIFF
--- a/data/apps/com.x8bit.bitwarden.json
+++ b/data/apps/com.x8bit.bitwarden.json
@@ -2,7 +2,7 @@
     "configs": [
         {
             "id": "com.x8bit.bitwarden",
-            "url": "https://github.com/bitwarden/android",
+            "url": "https://github.com/bitwarden/mobile",
             "author": "bitwarden",
             "name": "Bitwarden",
             "preferredApkIndex": 0,


### PR DESCRIPTION
The latest release for the legacy app was published on the old repo but not the new one.

The new repo also points to the old one for the legacy apps.