### PR TITLE
 Add Modal to Clarify Repository Purpose

### DIFF
--- a/data/strings.json
+++ b/data/strings.json
@@ -37,5 +37,17 @@
     "altConfigs": {
         "en": "Alternative Configurations",
         "de": "Andere Konfigurationen"
+    },
+    "modalTitle": {
+        "en": "Important – Please Read!"
+    },
+    "modalBody1": {
+        "en": "Before you request an app, please take a moment to consider whether the app you want would be suitable for this website. This website is primarily used for configs that people may find difficult to create. If the app you are requesting uses only the default options, please do not submit a request."
+    },
+    "modalBody2": {
+        "en": "If you decide to request an easy-to-add app anyway, your request may be ignored."
+    },
+    "modalButtonText": {
+        "en": "Continue →"
     }
 }

--- a/data/strings.json
+++ b/data/strings.json
@@ -48,6 +48,6 @@
         "en": "If you decide to request an easy-to-add app anyway, your request may be ignored."
     },
     "modalButtonText": {
-        "en": "Continue →"
+        "en": "Continue"
     }
 }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.1/css/bulma.min.css">
     <link rel="stylesheet" href="/data/style.css">
     <script src="script.js?v=20240113"></script>
     <title>Obtainium Apps</title>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
         <div class="columns">
             <div class="column is-half">
                 <h1 class="title" id="title">Obtainium Apps</h1>
-                <p class="subtitle" style="text-decoration: underline;"><a href="https://github.com/ImranR98/apps.obtainium.imranr.dev" target="_blank" id="subtitle" rel="noopener">Crowdsourced App Configurations for Obtainium</a></p>
-                <a class="button is-link is-medium is-fullwidth has-text-white" href="#" onclick="toggleModal()" id="request-apps" role="button" title="Request Apps">Request Apps</a>            </div>
+                <p class="subtitle" style="text-decoration: underline;"><a href="https://github.com/ImranR98/apps.obtainium.imranr.dev" target="_blank" rel="noopener" id="subtitle">Crowdsourced App Configurations for Obtainium</a></p>
+                <a class="button is-link is-medium is-fullwidth has-text-white" href="#" onclick="toggleModal()" id="request-apps" role="button" title="Request Apps">Request Apps</a>
+            </div>
             <div class="column is-half">
                 <div id="categories">
                 </div>
@@ -25,9 +26,11 @@
         </div>
         <div class="container" id="apps">
         </div>
+
     <noscript>
-    Enable JavaScript in your browser to see apps
+        Enable JavaScript in your browser to see apps
     </noscript>
+
     </section>
 
     <div class="modal" id="infoModal">
@@ -39,7 +42,7 @@
             </header>
             <section class="modal-card-body">
                 <p id="modal-body-1">Before you request an app, please take a moment to consider whether the app you want would be suitable for this website. This website is primarily used for configs that people may find difficult to create. If the app you are requesting uses only the default options, please do not submit a request.</p>
-                <br></br>
+                <br>
                 <p id="modal-body-2">If you decide to request an easy-to-add app anyway, your request may be ignored.</p>
             </section>
             <footer class="modal-card-foot">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.1/css/bulma.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
     <link rel="stylesheet" href="/data/style.css">
     <script src="script.js?v=20240113"></script>
     <title>Obtainium Apps</title>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div class="columns">
             <div class="column is-half">
                 <h1 class="title" id="title">Obtainium Apps</h1>
-                <p class="subtitle" style="text-decoration: underline;"><a href="https://github.com/ImranR98/apps.obtainium.imranr.dev" target="_blank" rel="noopener" id="subtitle">Crowdsourced App Configurations for Obtainium</a></p>
+                <p class="subtitle" style="text-decoration: underline;"><a href="https://github.com/ImranR98/apps.obtainium.imranr.dev" target="_blank" id="subtitle" rel="noopener">Crowdsourced App Configurations for Obtainium</a></p>
                 <a class="button is-link is-medium is-fullwidth has-text-white" href="#" onclick="toggleModal()" id="request-apps" role="button" title="Request Apps">Request Apps</a>
             </div>
             <div class="column is-half">

--- a/index.html
+++ b/index.html
@@ -17,8 +17,7 @@
             <div class="column is-half">
                 <h1 class="title" id="title">Obtainium Apps</h1>
                 <p class="subtitle" style="text-decoration: underline;"><a href="https://github.com/ImranR98/apps.obtainium.imranr.dev" target="_blank" id="subtitle" rel="noopener">Crowdsourced App Configurations for Obtainium</a></p>
-                <a class="button is-link is-medium is-fullwidth has-text-white" href="https://github.com/ImranR98/apps.obtainium.imranr.dev/discussions/new?category=app-requests" target="_blank" rel="noopener" id="request-apps" role="button" title="Request Apps">Request Apps</a>
-            </div>
+                <a class="button is-link is-medium is-fullwidth has-text-white" href="#" onclick="toggleModal()" id="request-apps" role="button" title="Request Apps">Request Apps</a>            </div>
             <div class="column is-half">
                 <div id="categories">
                 </div>
@@ -30,6 +29,24 @@
     Enable JavaScript in your browser to see apps
     </noscript>
     </section>
-</body>
 
+    <div class="modal" id="infoModal">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title" id="modal-title">Important – Please Read!</p>
+                <button class="delete" aria-label="close" onclick="toggleModal()"></button>
+            </header>
+            <section class="modal-card-body">
+                <p id="modal-body-1">Before you request an app, please take a moment to consider whether the app you want would be suitable for this website. This website is primarily used for configs that people may find difficult to create. If the app you are requesting uses only the default options, please do not submit a request.</p>
+                <br></br>
+                <p id="modal-body-2">If you decide to request an easy-to-add app anyway, your request may be ignored.</p>
+            </section>
+            <footer class="modal-card-foot">
+                <a href="https://github.com/ImranR98/apps.obtainium.imranr.dev/discussions/new?category=app-requests" class="button is-primary" id="modal-button" style="width: 100%; display: flex; justify-content: center; align-items: center;">Continue →</a>
+            </footer>
+        </div>
+    </div>
+
+</body>
 </html>

--- a/script.js
+++ b/script.js
@@ -191,6 +191,16 @@ function render() {
     document.querySelector('#title').innerHTML = getString('title')
     document.querySelector('#subtitle').innerHTML = getString('subtitle')
     document.querySelector('#request-apps').innerHTML = getString('requestAppsButton')
+    document.querySelector('#modal-title').innerHTML = getString('modalTitle')
+    document.querySelector('#modal-body-1').innerHTML = getString('modalBody1')
+    document.querySelector('#modal-body-2').innerHTML = getString('modalBody2')
+    document.querySelector('#modal-button').innerHTML = getString('modalButton')
+
+}
+
+function toggleModal() {
+    const modal = document.getElementById('infoModal');
+    modal.classList.toggle('is-active');
 }
 
 async function fetchAsync(url) {

--- a/script.js
+++ b/script.js
@@ -195,7 +195,6 @@ function render() {
     document.querySelector('#modal-body-1').innerHTML = getString('modalBody1')
     document.querySelector('#modal-body-2').innerHTML = getString('modalBody2')
     document.querySelector('#modal-button').innerHTML = getString('modalButtonText');
-
 }
 
 function toggleModal() {

--- a/script.js
+++ b/script.js
@@ -194,7 +194,7 @@ function render() {
     document.querySelector('#modal-title').innerHTML = getString('modalTitle')
     document.querySelector('#modal-body-1').innerHTML = getString('modalBody1')
     document.querySelector('#modal-body-2').innerHTML = getString('modalBody2')
-    document.querySelector('#modal-button').innerHTML = getString('modalButton')
+    document.querySelector('#modal-button').innerHTML = getString('modalButtonText');
 
 }
 

--- a/script.js
+++ b/script.js
@@ -194,7 +194,7 @@ function render() {
     document.querySelector('#modal-title').innerHTML = getString('modalTitle')
     document.querySelector('#modal-body-1').innerHTML = getString('modalBody1')
     document.querySelector('#modal-body-2').innerHTML = getString('modalBody2')
-    document.querySelector('#modal-button').innerHTML = getString('modalButtonText');
+    document.querySelector('#modal-button').innerHTML = getString('modalButtonText') + " →"
 }
 
 function toggleModal() {


### PR DESCRIPTION
This PR adds a modal that will be displayed when a user clicks the "Request Apps" button to explain that this website is for simple app configs.

![image](https://github.com/user-attachments/assets/7c6da899-153d-4560-93a4-f4815b9cf204)

Resolves #141