### PR TITLE
Change Quillpad's logo to match the rebrand

### DIFF
--- a/data/apps/io.github.quillpad.json
+++ b/data/apps/io.github.quillpad.json
@@ -8,7 +8,7 @@
             "additionalSettings": "{\"includePrereleases\":false,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"\",\"filterReleaseNotesByRegEx\":\"\",\"verifyLatestTag\":false,\"dontSortReleasesList\":false,\"useLatestAssetDateAsReleaseDate\":false,\"trackOnly\":false,\"versionExtractionRegEx\":\"\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"\",\"shizukuPretendToBeGooglePlay\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\"}"
         }
     ],
-    "icon": "https://github.com/quillpad/quillpad/blob/master/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png?raw=true",
+    "icon": "https://github.com/quillpad/quillpad/blob/master/graphics/quillpad-icon.svg?raw=true",
     "categories": ["notes", "text_editors"],
     "description": {
         "en": "Take beautiful markdown notes and stay organized with task lists. Fork of Quillnote"


### PR DESCRIPTION
Quillpad changed it's icon, and this pull request makes it point to the new logo, instead of pointing to the Quillnote icon.