### PR TITLE
Update FlorisBoard config (dual-track release support)

### DIFF
--- a/data/apps/dev.patrickgold.florisboard.beta.json
+++ b/data/apps/dev.patrickgold.florisboard.beta.json
@@ -4,16 +4,16 @@
             "id": "dev.patrickgold.florisboard.beta",
             "url": "https://github.com/florisboard/florisboard",
             "author": "florisboard",
-            "name": "FlorisBoard Beta",
+            "name": "FlorisBoard Preview",
             "preferredApkIndex": 0,
-            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"\",\"filterReleaseNotesByRegEx\":\"\",\"verifyLatestTag\":false,\"dontSortReleasesList\":false,\"trackOnly\":false,\"versionDetection\":\"standardVersionDetection\",\"apkFilterRegEx\":\"\",\"autoApkFilterByArch\":true,\"appName\":\"\",\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\"}"
+            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"apkFilterRegEx\":\"preview\"}"
         }
     ],
-    "icon": "https://raw.githubusercontent.com/florisboard/florisboard/master/app/src/main/res/mipmap-xxhdpi/ic_app_icon_beta.png",
+    "icon": "https://raw.githubusercontent.com/florisboard/florisboard/refs/heads/main/app/src/main/ic_app_icon_preview-playstore.png",
     "categories": [
         "keyboard"
     ],
     "description": {
-        "en": "A beta version of FlorisBoard, a customizable keyboard app for Android devices, offering features like gesture typing and theme customization."
+        "en": "Preview track of FlorisBoard, an open-source keyboard for Android which respects your privacy."
     }
 }

--- a/data/apps/dev.patrickgold.florisboard.json
+++ b/data/apps/dev.patrickgold.florisboard.json
@@ -1,0 +1,19 @@
+{
+    "configs": [
+        {
+            "id": "dev.patrickgold.florisboard",
+            "url": "https://github.com/florisboard/florisboard",
+            "author": "florisboard",
+            "name": "FlorisBoard Stable",
+            "preferredApkIndex": 0,
+            "additionalSettings": "{\"includePrereleases\":false,\"fallbackToOlderReleases\":true,\"apkFilterRegEx\":\"stable\"}"
+        }
+    ],
+    "icon": "https://raw.githubusercontent.com/florisboard/florisboard/refs/heads/main/app/src/main/ic_app_icon_stable-playstore.png",
+    "categories": [
+        "keyboard"
+    ],
+    "description": {
+        "en": "Stable track of FlorisBoard, an open-source keyboard for Android which respects your privacy."
+    }
+}


### PR DESCRIPTION
This PR updates the FlorisBoard configs for both tracks stable and preview. The configs are taken from [the FlorisBoard repo](https://github.com/florisboard/florisboard/tree/main/fastlane/obtainium). These extra configs are necessary, because FlorisBoard has a dual-track release scheme (stable and preview track) beginning from [v0.4.1](https://github.com/florisboard/florisboard/releases/tag/v0.4.1), where the correct APK must be chosen, which is not auto-configured by simply adding the GitHub link.