### PR TITLE
Add app criteria file

### DIFF
--- a/APP_CRITERIA.md
+++ b/APP_CRITERIA.md
@@ -1,0 +1,49 @@
+# App Criteria
+
+Hey,
+
+Before opening a new app request/PR with updates to a config, please read the following information to ensure that the app you want is suitable for this site. It will save you and the maintainers of the repo time. If you choose to ignore these instructions, your request/PR may be ignored.
+
+
+### Before opening an app request:
+
+1. Check the config website to see if the app you want is already available there.
+
+2. Search in both open AND closed discussions to see if this app has already been requested by someone else.
+
+3. Check if the app is a **simple config** - see below.
+
+4. Forks of apps will not be accepted, unless both the package name and display name of the app has been changed. This is to avoid people downloading non-official versions of apps.
+
+5. Only configs from official sources from the app are accepted. This means reupload site (eg. APKPure, APKMirror etc...) configs will NOT be added.
+
+
+If you have read through and understand the above, then you can [open an app request](https://github.com/ImranR98/apps.obtainium.imranr.dev/discussions/new?category=app-requests). Make sure to include at a minimum:
+
+- The link from where you can download the APK.
+- What you have tried to get the app working so far. If you have a working config, consider creating a PR yourself.
+
+
+### Before opening a PR:
+
+1. Search in both open AND closed PRs to see if someone has already tried to add the app at some point, and if it was declined, the reason why.
+
+2. Do not add apps that are **simple configs** - see below.
+
+3. Forks of apps will not be accepted, unless the app ID and name has been changed. This is to avoid people downloading non-official versions of apps without them knowing.
+
+4. Forks of apps will not be accepted, unless both the package name and display name of the app has been changed. This is to avoid people downloading non-official versions of apps.
+
+
+If you have read through all this and understand, then you can open an PR. Keep these things in mind:
+
+- If possible, provide an app description and icon in the JSON file.
+- Keep the amount of alternative configs to a minimum, only provide the ones that will work the best in the long term.
+- Ensure that you leave as many config options as you can as the default setting. Only change what you need. For example, with a GitHub config you would not add an app with the `Include prereleases` setting enabled unless necessary as not everyone will want prereleases.
+
+
+### What is a simple config?
+
+A simple config is an app that you can add by simply pasting the URL of the website and clicking add in Obtainium, without changing any additional settings. 
+
+The exception to this is if the URL may be hard to find. For example, the URL which has the links to Signal APKs (https://updates.signal.org/android/latest.json) is not easy to find unless you have knowledge of browser developer tools.

--- a/APP_CRITERIA.md
+++ b/APP_CRITERIA.md
@@ -44,6 +44,6 @@ If you have read through all this and understand, then you can open an PR. Keep 
 
 ### What is a simple config?
 
-A simple config is an app that you can add by simply pasting the URL of the website and clicking add in Obtainium, without changing any additional settings. 
+A simple config is an app that you can add by simply pasting the URL of the website and clicking add in Obtainium, without changing any additional settings.
 
 The exception to this is if the URL may be hard to find. For example, the URL which has the links to Signal APKs (https://updates.signal.org/android/latest.json) is not easy to find unless you have knowledge of browser developer tools.

--- a/APP_CRITERIA.md
+++ b/APP_CRITERIA.md
@@ -1,7 +1,5 @@
 # App Criteria
 
-Hey,
-
 Before opening a new app request/PR with updates to a config, please read the following information to ensure that the app you want is suitable for this site. It will save you and the maintainers of the repo time. If you choose to ignore these instructions, your request/PR may be ignored.
 
 
@@ -11,14 +9,14 @@ Before opening a new app request/PR with updates to a config, please read the fo
 
 2. Search in both open AND closed discussions to see if this app has already been requested by someone else.
 
-3. Check if the app is a **simple config** - see below.
+3. Do not request apps that are **simple configs** - see below.
 
-4. Forks of apps will not be accepted, unless both the package name and display name of the app has been changed. This is to avoid people downloading non-official versions of apps.
+4. Forks of apps will not be accepted, unless both the package name and display name of the app has been changed. This is so people do not unknowingly download unofficial versions of apps.
 
 5. Only configs from official sources from the app are accepted. This means reupload site (eg. APKPure, APKMirror etc...) configs will NOT be added.
 
 
-If you have read through and understand the above, then you can [open an app request](https://github.com/ImranR98/apps.obtainium.imranr.dev/discussions/new?category=app-requests). Make sure to include at a minimum:
+If you've gone through the above steps, then you can [open an app request](https://github.com/ImranR98/apps.obtainium.imranr.dev/discussions/new?category=app-requests). Make sure to include at a minimum:
 
 - The link from where you can download the APK.
 - What you have tried to get the app working so far. If you have a working config, consider creating a PR yourself.
@@ -30,14 +28,12 @@ If you have read through and understand the above, then you can [open an app req
 
 2. Do not add apps that are **simple configs** - see below.
 
-3. Forks of apps will not be accepted, unless the app ID and name has been changed. This is to avoid people downloading non-official versions of apps without them knowing.
+3. Forks of apps will not be accepted, unless both the package name and display name of the app has been changed. This is so people do not unknowingly download unofficial versions of apps.
 
-4. Forks of apps will not be accepted, unless both the package name and display name of the app has been changed. This is to avoid people downloading non-official versions of apps.
+4. Only configs from official sources from the app are accepted. This means reupload site (eg. APKPure, APKMirror etc...) configs will NOT be added.
 
+If you've gone through the above steps, then you can open an PR. Keep these things in mind:
 
-If you have read through all this and understand, then you can open an PR. Keep these things in mind:
-
-- If possible, provide an app description and icon in the JSON file.
 - Keep the amount of alternative configs to a minimum, only provide the ones that will work the best in the long term.
 - Ensure that you leave as many config options as you can as the default setting. Only change what you need. For example, with a GitHub config you would not add an app with the `Include prereleases` setting enabled unless necessary as not everyone will want prereleases.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+## Contributing
+
+- To contribute content, create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) with valid changes/additions to any files in the repo.
+- To test locally, run: `node buildData.js && python -m http.server 8080`
+- See https://github.com/ImranR98/Obtainium/issues/1214 for background/context for this repo.
+
+
+## Contributing Apps
+
+> [!IMPORTANT]
+> Please make sure to read the [app criteria](APP_CRITERIA.md) before opening a PR with new/updated app configs. 
+
+- You can auto-generate config files from an Obtainium export by running `node generateFromExport.js <path to Obtainium export>`
+- Note: Auto-generated entries will not have icon, category, or description data. Adding those manually is not required but would result in a better user experience.
+- You can also auto-generate config files from an Obtainium URL redirection link by running `generate_from_url.py`
+- Note: Using `generate_from_url.py` requires you to install "Colorama" by using the `pip` command `pip install colorama`
+
+
+### Minimal Example
+
+To add an app config to this repo, your app configuration JSON must contain at least the `id`, `url`, `author`, `name`, and `additionalSettings` keys. Note that for any app-specific setting you don't define in `additionalSettings`, the default value will be used.
+
+For example:
+- Minimal app JSON: `{"id":"dev.patrickgold.florisboard.beta","url":"https://github.com/florisboard/florisboard","author":"florisboard","name":"FlorisBoard Beta","additionalSettings":"{\"includePrereleases\":true}"}`
+- As URL: http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22dev.patrickgold.florisboard.beta%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fflorisboard%2Fflorisboard%22%2C%22author%22%3A%22florisboard%22%2C%22name%22%3A%22FlorisBoard%20Beta%22%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Atrue%7D%22%7D 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 ## Contributing Apps
 
 > [!IMPORTANT]
-> Please make sure to read the [app criteria](APP_CRITERIA.md) before opening a PR with new/updated app configs. 
+> Please make sure to read the [app criteria](APP_CRITERIA.md) before opening a PR with new/updated app configs.
 
 - You can auto-generate config files from an Obtainium export by running `node generateFromExport.js <path to Obtainium export>`
 - Note: Auto-generated entries will not have icon, category, or description data. Adding those manually is not required but would result in a better user experience.
@@ -22,4 +22,4 @@ To add an app config to this repo, your app configuration JSON must contain at l
 
 For example:
 - Minimal app JSON: `{"id":"dev.patrickgold.florisboard.beta","url":"https://github.com/florisboard/florisboard","author":"florisboard","name":"FlorisBoard Beta","additionalSettings":"{\"includePrereleases\":true}"}`
-- As URL: http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22dev.patrickgold.florisboard.beta%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fflorisboard%2Fflorisboard%22%2C%22author%22%3A%22florisboard%22%2C%22name%22%3A%22FlorisBoard%20Beta%22%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Atrue%7D%22%7D 
+- As URL: http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22dev.patrickgold.florisboard.beta%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fflorisboard%2Fflorisboard%22%2C%22author%22%3A%22florisboard%22%2C%22name%22%3A%22FlorisBoard%20Beta%22%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Atrue%7D%22%7D

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@ Crowdsourced App Configurations website for [Obtainium](https://github.com/Imran
 
 The website is accessible at [apps.obtainium.imranr.dev](https://apps.obtainium.imranr.dev)
 
-## URL Redirection
+## About
+
+This website has **two** main parts:
+
+- URL Redirection page (redirect.html)
+- Crowdsourced app configs (main page)
+
+For contributing new configs see the [contributing guidelines](CONTRIBUTING.md). For how to use the redirection page, see below:
+
+
+### URL Redirection
 
 Obtainium's custom protocol links (`obtainium://`) may not be easily clickable (for example, neither GitHub's MarkDown renderer nor popular messaging apps like WhatsApp support them). To work around this, you can use the web-based redirect to get a normal `http://` link that opens a webpage which redirects to Obtainium (if installed).
 
@@ -12,7 +22,8 @@ For example:
 - Raw Obtainium link: `obtainium://add/https://github.com/florisboard/florisboard`
 - Clickable redirect version: http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/florisboard/florisboard
 
-## Link Types
+
+### Link Types
 
 As of this writing, there are two types of Obtainium links:
 
@@ -20,23 +31,6 @@ As of this writing, there are two types of Obtainium links:
 2. `/app`: These links contain an entire app configuration JSON and opening them in Obtainium results in the app being added directly into the user's list, with the app-specific settings included in the link.
    - Example: http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22dev.patrickgold.florisboard.beta%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fflorisboard%2Fflorisboard%22%2C%22author%22%3A%22florisboard%22%2C%22name%22%3A%22FlorisBoard%20Beta%22%2C%22preferredApkIndex%22%3A0%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Atrue%2C%5C%22fallbackToOlderReleases%5C%22%3Atrue%2C%5C%22filterReleaseTitlesByRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22filterReleaseNotesByRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22verifyLatestTag%5C%22%3Afalse%2C%5C%22dontSortReleasesList%5C%22%3Afalse%2C%5C%22trackOnly%5C%22%3Afalse%2C%5C%22versionDetection%5C%22%3A%5C%22standardVersionDetection%5C%22%2C%5C%22apkFilterRegEx%5C%22%3A%5C%22%5C%22%2C%5C%22autoApkFilterByArch%5C%22%3Atrue%2C%5C%22appName%5C%22%3A%5C%22%5C%22%2C%5C%22exemptFromBackgroundUpdates%5C%22%3Afalse%2C%5C%22skipUpdateNotifications%5C%22%3Afalse%2C%5C%22about%5C%22%3A%5C%22%5C%22%7D%22%7D
 
-## Minimal Example
-
-To add an app config to this repo, your app configuration JSON must contain at least the `id`, `url`, `author`, `name`, and `additionalSettings` keys. Note that for any app-specific setting you don't define in `additionalSettings`, the default value will be used.
-
-For example:
-- Minimal app JSON: `{"id":"dev.patrickgold.florisboard.beta","url":"https://github.com/florisboard/florisboard","author":"florisboard","name":"FlorisBoard Beta","additionalSettings":"{\"includePrereleases\":true}"}`
-- As URL: http://apps.obtainium.imranr.dev/redirect.html?r=obtainium://app/%7B%22id%22%3A%22dev.patrickgold.florisboard.beta%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fflorisboard%2Fflorisboard%22%2C%22author%22%3A%22florisboard%22%2C%22name%22%3A%22FlorisBoard%20Beta%22%2C%22additionalSettings%22%3A%22%7B%5C%22includePrereleases%5C%22%3Atrue%7D%22%7D
-
-## Contributing
-
-- To contribute content, create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) with valid changes/additions to the config files in `data/`.
-  - You can auto-generate config files from an Obtainium export by running `node generateFromExport.js <path to Obtainium export>`
-  - Note: Auto-generated entries will not have icon, category, or description data. Adding those manually is not required but would result in a better user experience.
-  - You can also auto-generate config files from an Obtainium URL redirection link by running `generate_from_url.py`
-  - Note: Using `generate_from_url.py` requires you to install "Colorama" by using the `pip` command `pip install colorama`
-- To test locally, run: `node buildData.js && python -m http.server 8080`
-- See https://github.com/ImranR98/Obtainium/issues/1214 for background/context for this repo.
 
 ## Badge Graphic
 


### PR DESCRIPTION
I've added a file with the requirements for the apps in an MD file. People can be pointed to read it when they request an unsuitable app. Let me know what you think and if it can be improved.

In the future, the app request dialog could link to that file instead of the current text. A GitHub actions workflow could also be made  that will auto-respond to new app requests telling them to read the app criteria file.

I also moved the contributing guidelines out of the README and into a seperate file. When making a PR GitHub prompts the user to read the CONTRIBUTING.md file, so people should see the app criteria before creating a PR. 