### PR TITLE
PeerTube mobile app

### DIFF
--- a/data/apps/org.framasoft.peertube.json
+++ b/data/apps/org.framasoft.peertube.json
@@ -1,0 +1,20 @@
+{
+    "apps": [
+        {
+            "id": "org.framasoft.peertube",
+            "url": "https://asso.framasoft.org/dolo/h/peertube-apk-latest",
+            "author": "asso.framasoft.org",
+            "name": "PeerTube",
+            "icon": "https://framagit.org/framasoft/peertube/mobile-application/-/raw/develop/assets/icon_with_background.png",
+            "categories": [
+                "video_player",
+                "media_frontends",
+                "community_clients"
+            ],
+            "description": {
+                "en": "PeerTube mobile app: discover videos while caring for your attention."
+            },
+            "overrideSource": "DirectAPKLink"
+        }
+    ]
+}


### PR DESCRIPTION
This is their official APK release. They may switch to F-Droid only once it is released, but for now it is the only way to get the app without Google.

For anyone who wants to try the config, I attach it.

[org.framasoft.peertube.json](https://github.com/user-attachments/files/18132451/org.framasoft.peertube.json)
