### PR TITLE
Don’t hotlink PeerTube icon from repository

### DIFF
--- a/data/apps/org.framasoft.peertube.json
+++ b/data/apps/org.framasoft.peertube.json
@@ -8,7 +8,7 @@
             "overrideSource": "DirectAPKLink"
         }
     ],
-    "icon": "https://framagit.org/framasoft/peertube/mobile-application/-/raw/develop/assets/icon_with_background.png",
+    "icon": "https://framasoft.frama.io/peertube/mobile-application/icon_with_background.png",
     "categories": [
         "video_player",
         "media_frontends",


### PR DESCRIPTION
We deployed the icon on a static site to let you hotlink it from there. The static site is automatically deployed from CI, so if the icon change in the app, it will be automatically updated on the static site.