### PR TITLE
Add IronFox

### DIFF
--- a/data/apps/org.ironfoxoss.ironfox.json
+++ b/data/apps/org.ironfoxoss.ironfox.json
@@ -1,0 +1,20 @@
+{
+    "configs": [
+        {
+            "id": "org.ironfoxoss.ironfox",
+            "url": "https://fdroid.ironfoxoss.org/fdroid/repo/",
+            "author": "IronFox OSS",
+            "name": "IronFox",
+            "additionalSettings": "{\"appIdOrName\":\"org.ironfoxoss.ironfox\",\"pickHighestVersionCode\":false,\"trackOnly\":false,\"versionExtractionRegEx\":\"\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"\",\"shizukuPretendToBeGooglePlay\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\"}",
+            "overrideSource": "FDroidRepo",
+            "altLabel": "IronFox OSS F-Droid"
+        }
+    ],
+    "icon": "https://gitlab.com/ironfox-oss/IronFox/-/raw/main/assets/ironfox.png",
+    "description": {
+        "en": "IronFox is a secure, hardened and privacy-oriented web browser for Android, based on Firefox."
+    },
+    "categories": [
+        "browser"
+    ]
+}


### PR DESCRIPTION
IronFox is a fork of [Divested Computing Group](https://divested.dev/)'s [Mull Browser](https://divestos.org/pages/our_apps#mull), based on [Mozilla Firefox](https://www.mozilla.org/firefox/).