### PR TITLE
Fix com.collabora.libreoffice.* URL values.

### DIFF
--- a/data/apps/com.collabora.libreoffice.json
+++ b/data/apps/com.collabora.libreoffice.json
@@ -2,7 +2,7 @@
     "configs": [
         {
             "id": "com.collabora.libreoffice",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release/",
             "author": "Collabora Productivity",
             "name": "Collabora Office",
             "preferredApkIndex": 0,
@@ -16,7 +16,7 @@
         },
         {
             "id": "com.collabora.libreoffice",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release/",
             "author": "Collabora Productivity",
             "name": "Collabora Office",
             "preferredApkIndex": 0,
@@ -30,7 +30,7 @@
         },
         {
             "id": "com.collabora.libreoffice",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release/",
             "author": "Collabora Productivity",
             "name": "Collabora Office",
             "preferredApkIndex": 0,
@@ -44,7 +44,7 @@
         },
         {
             "id": "com.collabora.libreoffice",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Release/",
             "author": "Collabora Productivity",
             "name": "Collabora Office",
             "preferredApkIndex": 0,

--- a/data/apps/com.collabora.libreoffice.snapshot.json
+++ b/data/apps/com.collabora.libreoffice.snapshot.json
@@ -2,7 +2,7 @@
     "configs": [
         {
             "id": "com.collabora.libreoffice.snapshot",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot/",
             "author": "Collabora Productivity",
             "name": "Collabora Office (Snapshot)",
             "preferredApkIndex": 0,
@@ -16,7 +16,7 @@
         },
         {
             "id": "com.collabora.libreoffice.snapshot",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot/",
             "author": "Collabora Productivity",
             "name": "Collabora Office (Snapshot)",
             "preferredApkIndex": 0,
@@ -30,7 +30,7 @@
         },
         {
             "id": "com.collabora.libreoffice.snapshot",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot/",
             "author": "Collabora Productivity",
             "name": "Collabora Office (Snapshot)",
             "preferredApkIndex": 0,
@@ -44,7 +44,7 @@
         },
         {
             "id": "com.collabora.libreoffice.snapshot",
-            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot",
+            "url": "https://collaboraoffice.com/downloads/Collabora-Office-Android-Snapshot/",
             "author": "Collabora Productivity",
             "name": "Collabora Office (Snapshot)",
             "preferredApkIndex": 0,


### PR DESCRIPTION
Updating Collabora office broke with release v1.1.53 (likely related to https://github.com/ImranR98/Obtainium/pull/2273).

With version v1.1.53 the APK URL doesn't work and looks like this:

`https://collaboraoffice.com/downloads/collabora-office-mobile-24-04-release-arm64-v8a-2025-04-15.apk`

With the added slash, the last part of the URL - *Collabora-Office-Android-Release* is not removed from the actual APK URL, it does work again and looks like this:

`https://collaboraoffice.com/downloads/Collabora-Office-Android-Release/collabora-office-mobile-24-04-release-arm64-v8a-2025-04-15.apk`

