### PR TITLE
Fix app.organicmaps.web URL values

### DIFF
--- a/data/apps/app.organicmaps.web.json
+++ b/data/apps/app.organicmaps.web.json
@@ -2,17 +2,15 @@
     "configs": [
         {
             "id": "app.organicmaps.web",
-            "url": "https://git.omaps.dev/organicmaps/organicmaps/",
+            "url": "https://github.com/organicmaps/organicmaps",
             "author": "organicmaps",
             "name": "Organic Maps",
             "additionalSettings": "{\"apkFilterRegEx\":\"web\"}",
             "overrideSource": "Codeberg"
-         }
+        }
     ],
-    "icon": "https://git.omaps.dev/organicmaps/organicmaps/raw/branch/master/qt/res/logo.png",
-    "categories": [
-        "maps_and_navigation"
-    ],
+    "icon": "https://github.com/organicmaps/organicmaps/blob/master/qt/res/logo.png",
+    "categories": ["maps_and_navigation"],
     "description": {
         "en": "Organic Maps is a free Android & iOS offline maps app for travellers, tourists, drivers, hikers, and cyclists."
     }


### PR DESCRIPTION
Organic Maps has archived their old repo hosted at `https://git.omaps.dev/organicmaps/organicmaps/`, in favor of having moved to a GitHub repo at `https://github.com/organicmaps/organicmaps`