### PR TITLE
Add Privacy Browser

### DIFF
--- a/data/apps/com.stoutner.privacybrowser.standard.json
+++ b/data/apps/com.stoutner.privacybrowser.standard.json
@@ -1,0 +1,17 @@
+{
+  "configs": [
+    {
+      "id": "com.stoutner.privacybrowser.standard",
+      "url": "https://download.stoutner.com/privacy-browser/",
+      "author": "Soren Stoutner",
+      "name": "Privacy Browser",
+      "additionalSettings": "{\"intermediateLink\":[],\"customLinkFilterRegex\":\"\",\"filterByLinkText\":false,\"skipSort\":false,\"reverseSort\":false,\"sortByLastLinkSegment\":false,\"versionExtractWholePage\":false,\"requestHeader\":[{\"requestHeader\":\"User-Agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36\"}],\"defaultPseudoVersioningMethod\":\"APKLinkHash\",\"trackOnly\":false,\"versionExtractionRegEx\":\"\\\\d+(?:\\\\.\\\\d+){1,2}\",\"matchGroupToUse\":\"\",\"versionDetection\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"\",\"shizukuPretendToBeGooglePlay\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\",\"supportFixedAPKURL\":false,\"sortByFileNamesNotLinks\":false,\"intermediateLinkRegex\":\"\"}",
+      "overrideSource": "HTML"
+    }
+  ],
+  "icon": "https://gitweb.stoutner.com/?p=PrivacyBrowserAndroid.git;a=blob_plain;f=app/src/main/assets/shared_images/privacy_browser.svg",
+  "categories": ["browser"],
+  "description": {
+    "en": "An open source Android web browser focused on user privacy."
+  }
+}


### PR DESCRIPTION
Resolves #706

This is based on [another config](https://github.com/ImranR98/apps.obtainium.imranr.dev/blob/621a2be406dd9df355df52d5e46f547c411de1c6/data/apps/com.stoutner.privacycell.json) for a different app by the same developer.

I did notice that with this configuration 3.19 is being considered the latest version whereas 3.19.3 is the correct latest version. Is this a bug in Obtainium or something that can be fixed in the configuration?