### PR TITLE
su.xash.engine.test.json: Add Xash3D FWGS config

### DIFF
--- a/data/apps/su.xash.engine.test.json
+++ b/data/apps/su.xash.engine.test.json
@@ -5,7 +5,7 @@
             "url": "https://github.com/FWGS/xash3d-fwgs",
             "author": "FWGS Team",
             "name": "Xash3D FWGS",
-            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":false,\"filterReleaseTitlesByRegEx\":\"master Build\",\"releaseDateAsVersion\":true}"
+            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"master Build\",\"releaseDateAsVersion\":true}"
         }
     ],
     "icon": "https://github.com/FWGS/xash3d-fwgs/blob/master/game_launch/icon-xash-material.png?raw=true",


### PR DESCRIPTION
Has to add this because without this json, it can't find apk. With `includePrereleases` enabled, sometime it downloaded from wrong branch, used `filterReleaseTitlesByRegEx` to correct it. Used release date as version.