### PR TITLE
Add KOReader to the Category "Document & PDF Viewer"

### DIFF
--- a/data/apps/org.koreader.launcher.json
+++ b/data/apps/org.koreader.launcher.json
@@ -12,6 +12,7 @@
     "icon": "https://avatars.githubusercontent.com/u/3957564?s=200&v=4",
     "categories": [
         "utilities",
+        "document_and_pdf_viewer",
         "anime_and_manga"
     ],
     "description": {


### PR DESCRIPTION
Since KOReader is an E-Book reader, it fits the criteria to fit in the Document & PDF Viewer category, even more so since KOReader can be used to view PDF files.