### PR TITLE
com.github.catfriend1.syncthingandroid.json: adapt to changed app ID

### DIFF
--- a/data/apps/com.github.catfriend1.syncthingfork.json
+++ b/data/apps/com.github.catfriend1.syncthingfork.json
@@ -1,7 +1,7 @@
 {
     "configs": [
         {
-            "id": "com.github.catfriend1.syncthingandroid",
+            "id": "com.github.catfriend1.syncthingfork",
             "url": "https://github.com/Catfriend1/syncthing-android",
             "author": "Catfriend1",
             "name": "Syncthing-Fork",


### PR DESCRIPTION
App signature has changed from `syncthingandroid` to `syncthingfork`.

I'm not sure whether this means the JSON file must be renamed, too — and whether there is a way to automatically get this change to existing users? 