### PR TITLE
Fix Arcaea version regex

### DIFF
--- a/data/apps/moe.low.arc.json
+++ b/data/apps/moe.low.arc.json
@@ -6,7 +6,7 @@
             "author": "lowiro",
             "name": "Arcaea",
             "preferredApkIndex": 0,
-            "additionalSettings": "{\"customLinkFilterRegex\":\"arcaea-static.lowiro-cdn.net\",\"versionExtractionRegEx\":\"\\\\d\\\\.\\\\d\\\\.\\\\d\",\"about\":\"New Dimension Rhythm Game - Experience sound and story unlike ever before\"}",
+            "additionalSettings": "{\"customLinkFilterRegex\":\"arcaea-static.lowiro-cdn.net\",\"versionExtractionRegEx\":\"\\\\d+\\\\.\\\\d+\\\\.\\\\d+\",\"about\":\"New Dimension Rhythm Game - Experience sound and story unlike ever before\"}",
             "altLabel": "c"
         }
     ],


### PR DESCRIPTION
Currently the game is at version `6.10.3`, which breaks the regex `\d\.\d\.\d`. Change to `\d+\.\d+\.\d+` instead. Close #960.