### PR TITLE
Update Signal configuration

### DIFF
--- a/data/apps/org.thoughtcrime.securesms.json
+++ b/data/apps/org.thoughtcrime.securesms.json
@@ -3,19 +3,19 @@
         {
             "id": "org.thoughtcrime.securesms",
             "url": "https://updates.signal.org/android/latest.json",
-            "author": "Signal",
+            "author": "updates.signal.org",
             "name": "Signal",
             "preferredApkIndex": 0,
-            "additionalSettings": "{\"intermediateLink\":[],\"customLinkFilterRegex\":\"\",\"filterByLinkText\":false,\"skipSort\":false,\"reverseSort\":false,\"sortByLastLinkSegment\":false,\"versionExtractWholePage\":false,\"requestHeader\":[{\"requestHeader\":\"User-Agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36\"}],\"defaultPseudoVersioningMethod\":\"partialAPKHash\",\"trackOnly\":false,\"versionExtractionRegEx\":\"\\\\d+.\\\\d+.\\\\d+\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"\",\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\"}",
+            "additionalSettings": "{\"intermediateLink\":[],\"customLinkFilterRegex\":\"\",\"filterByLinkText\":false,\"matchLinksOutsideATags\":false,\"skipSort\":false,\"reverseSort\":false,\"sortByLastLinkSegment\":false,\"versionExtractWholePage\":true,\"requestHeader\":[{\"requestHeader\":\"User-Agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36\"}],\"defaultPseudoVersioningMethod\":\"partialAPKHash\",\"trackOnly\":false,\"versionExtractionRegEx\":\"\\\"versionName\\\"\\\\s*:\\\\s*\\\"([^\\\"]*)\\\"\",\"matchGroupToUse\":\"$1\",\"versionDetection\":true,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"Signal\",\"appAuthor\":\"Signal Technology Foundation\",\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"Signal is an open-source end-to-end encrypted messaging app.\",\"refreshBeforeDownload\":false}",
             "overrideSource": null
         }
     ],
-    "icon": "https://avatars.githubusercontent.com/u/702459?s=200&v=4",
+    "icon": "https://avatars.githubusercontent.com/signalapp?s=200&v=4",
     "categories": [
         "messaging"
     ],
     "description": {
-        "en": "Signal is an open-source end to end encrypted messaging app.",
-        "de": "Signal ist ein quelloffener Ende zu Ende verschlüsselter Messenger."
+        "en": "Signal is an open-source end-to-end encrypted messaging app.",
+        "de": "Signal ist ein quelloffener Ende-zu-Ende-verschlüsselter Messenger."
     }
 }


### PR DESCRIPTION
Addresses #1136
Addresses ImranR98/Obtainium#2715

Recently, the Signal apks have changed to no longer include the version name in the filename or URL, and this breaks existing configurations, with the error "Could not determine release version", because the version extraction logic is carried out on the URL.

The version string is already provided in the JSON object at [https://updates.signal.org/android/latest.json](https://updates.signal.org/android/latest.json), under the field `versionName`, so I changed the version extraction logic as follows:
- I set `"versionExtractWholePage": true`; that is: toggle on the option _Apply version string extraction Regex to entire page_.
- I changed the RegEx filter `"versionExtractionRegEx"` (which is the option _Version string extraction RegEx_) to the following, to extract the field `versionName` from the JSON:
  ```regex
  "versionName"\s*:\s*"([^"]*)"
  ```
- I set `"matchGroupToUse": "$1"`; that is, put `$1` in the option _Match group to use for version string extraction RegEx_.

I also made some other minor changes:
- I added the new fields `matchLinksOutsideATags` and `refreshBeforeDownload` (with their default values)
- I set `appName` and `appAuthor`
- I added hyphens in "end-to-end encrypted" (instead of "end to end" without hyphens) in the descriptions
- I set `"author": "updates.signal.org"` because that's what Obtainium sets when importing and exporting the app

---

Note that now the URL for the latest apk is always the same `https://updates.signal.org/android/Signal-Android-website-prod-universal-release-unsigned.apk`, so technically one could now add Signal with a direct apk link, but the approach of using `https://updates.signal.org/android/latest.json` is more future-proof and allows to determine the version.