### PR TITLE
Links to verification hash for Proton Apps

### DIFF
--- a/data/apps/me.proton.android.calendar.json
+++ b/data/apps/me.proton.android.calendar.json
@@ -9,6 +9,7 @@
         }
     ],
     "icon": "https://play-lh.googleusercontent.com/v1Qfdb9p3Fi09V9uTOQpapUedtH96_SGG3rDbkd2D8iso0B4cmDUrJJfqH0RBJjtM_o=w480-h960",
+    "apkVerificationLocation": "https://protonapps.com/protoncalendar-android#hash",
     "categories": ["calendar"],
     "description": {
         "en": "Secure, encrypted calendar for your Android devices."

--- a/data/apps/proton.android.pass.json
+++ b/data/apps/proton.android.pass.json
@@ -11,6 +11,7 @@
         }
     ],
     "icon": "https://github.com/protonpass/android-pass/blob/main/app/src/main/ic_launcher-playstore.png?raw=true",
+    "apkVerificationLocation": "https://protonapps.com/protonpass-android#hash",
     "categories": [
         "password_and_authentication"
     ],


### PR DESCRIPTION
This pull requests adds the missing references to the SHA256 fingerprint of Proton's signing certificate into the Proton Pass and Proton Calendar configurations.