### PR TITLE
correct a typo in com.best.deskclock’s config file

### DIFF
--- a/data/apps/com.best.deskclock.json
+++ b/data/apps/com.best.deskclock.json
@@ -13,7 +13,7 @@
             "url": "https://github.com/BlackyHawky/Clock",
             "author": "BlackyHawky",
             "name": "Clock",
-            "additionalSettings": "{\"includePrereleases\":false,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"\",\"filterReleaseNotesByRegEx\":\"\",\"verifyLatestTag\":false,\"sortMethodChoice\":\"date\",\"useLatestAssetDateAsReleaseDate\":false,\"releaseTitleAsVersion\":false,\"trackOnly\":false,\"versionExtractionRegEx\":\"\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"dubug\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"refreshBeforeDownload\":false}",
+            "additionalSettings": "{\"includePrereleases\":false,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"\",\"filterReleaseNotesByRegEx\":\"\",\"verifyLatestTag\":false,\"sortMethodChoice\":\"date\",\"useLatestAssetDateAsReleaseDate\":false,\"releaseTitleAsVersion\":false,\"trackOnly\":false,\"versionExtractionRegEx\":\"\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"debug\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"refreshBeforeDownload\":false}",
             "altLabel": "Debug"
         }
     ],


### PR DESCRIPTION
In the [`data/apps/com.best.deskclock.json`](https://github.com/ImranR98/apps.obtainium.page/edit/main/public/data/apps/complex/com.best.deskclock.json) file, there is `\"apkFilterRegEx\":\"dubug\"` instead of `\"apkFilterRegEx\":\"debug\"` in the value of the `.configs.[1].additionalSettings` JSON key. So, currently, APKs for this app are not filtered out correctly by Obtainium if this configuration is in use.