### PR TITLE
Edit "wrong" label for dev.imranr.obtainium’s config

### DIFF
--- a/data/apps/dev.imranr.obtainium.json
+++ b/data/apps/dev.imranr.obtainium.json
@@ -2,11 +2,11 @@
     "configs": [
         {
             "id": "dev.imranr.obtainium",
-            "url": "https://github.com/imranr98/obtainium",
-            "author": "imranr98",
+            "url": "https://github.com/ImranR98/Obtainium",
+            "author": "ImranR98",
             "name": "Obtainium",
             "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"\",\"filterReleaseNotesByRegEx\":\"\",\"verifyLatestTag\":false,\"dontSortReleasesList\":false,\"useLatestAssetDateAsReleaseDate\":false,\"trackOnly\":false,\"versionExtractionRegEx\":\"\",\"matchGroupToUse\":\"\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"fdroid\",\"invertAPKFilter\":true,\"autoApkFilterByArch\":true,\"shizukuPretendToBeGooglePlay\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false}",
-            "altLabel": "GitHub (F-Droid variant)"
+            "altLabel": "GitHub (F-Droid variant excluded)"
         }
     ],
     "icon": "https://github.com/ImranR98/Obtainium/raw/main/assets/graphics/icon_small.png",


### PR DESCRIPTION
This file ([`data/apps/dev.imranr.obtainium.json`](https://github.com/ImranR98/apps.obtainium.page/blob/main/public/data/apps/complex/dev.imranr.obtainium.json)) has contained `"id": "dev.imranr.obtainium"` and `\"apkFilterRegEx\":\"fdroid\",\"invertAPKFilter\":true` since [its first commit](https://github.com/ImranR98/apps.obtainium.imranr.dev/commit/a6a6571684f4cc9e5fb6bde0d2e8d30343e5960b#diff-ea8aabf2c8c7a5ae70da5bb4dedb23715d67c38d15295b93c62a10253ddad7cc). So it seems to correspond to a configuration for the regular variant of Obtainium, **NOT** for the F-Droid one, whose app ID is `dev.imranr.obtainium.fdroid`.

Then in [this later commit](https://github.com/ImranR98/apps.obtainium.imranr.dev/commit/2b01160d6533e4dfd1d05a8c0e7d47408e4ff1d0#diff-ea8aabf2c8c7a5ae70da5bb4dedb23715d67c38d15295b93c62a10253ddad7cc), you can see that the value for the `"additionalSettings"` key has not changed since the 1st commit, and that someome added `"altLabel": "GitHub (F-Droid variant)"`. I assume this was an error (Maybe they didn't pay attention to `\"invertAPKFilter\":true`). 

So I propose to replace `"altLabel": "GitHub (F-Droid variant)"` with `"altLabel": "GitHub (F-Droid variant excluded)"`.