### PR TITLE
Add configuration for Eddie - AirVPN GUI

### DIFF
--- a/public/data/apps/complex/org.airvpn.eddie.json
+++ b/public/data/apps/complex/org.airvpn.eddie.json
@@ -1,0 +1,20 @@
+{
+    "configs": [
+        {
+            "id": "org.airvpn.eddie",
+            "url": "https://eddie.website/api/download.php?platform=android",
+            "author": "AirVPN",
+            "name": "Eddie - AirVPN GUI",
+            "preferredApkIndex": 0,
+            "additionalSettings": "{\"intermediateLink\":[],\"customLinkFilterRegex\":\"\",\"filterByLinkText\":false,\"matchLinksOutsideATags\":false,\"skipSort\":false,\"reverseSort\":false,\"sortByLastLinkSegment\":false,\"versionExtractWholePage\":false,\"requestHeader\":[{\"requestHeader\":\"User-Agent: Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36\"}],\"defaultPseudoVersioningMethod\":\"partialAPKHash\",\"trackOnly\":false,\"versionExtractionRegEx\":\"EddieAndroid-(.+)\\\\.apk\",\"matchGroupToUse\":\"$1\",\"versionDetection\":true,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"\",\"appAuthor\":\"AirVPN\",\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"\",\"refreshBeforeDownload\":false}",
+            "overrideSource": null
+        }
+    ],
+    "icon": "https://eddie.website/images/icon.png",
+    "categories": [
+        "vpn"
+    ],
+    "description": {
+        "en": "The official AirVPN client GUI with full WireGuard, Amnezia and OpenVPN support"
+    }
+}


### PR DESCRIPTION
Most additional settings left as defaults, only version regex settings changed to extract version from the filename. Currently extracted version includes the version code (e.g. `4.0.1-VC39`), wasn't sure if it was better to include or exclude this. 

URL is official website that returns a JSON response
Description taken from first line of Play Store description
App entry created by `scripts/generate_from_url.py` and edited to add info