### PR TITLE
Add Prism (UnifiedPush distributor)

### DIFF
--- a/public/data/apps/complex/app.lonecloud.prism.json
+++ b/public/data/apps/complex/app.lonecloud.prism.json
@@ -10,7 +10,7 @@
     ],
     "icon": "https://git.lonecloud.dev/lone-cloud/prism-android/raw/branch/main/assets/prism.webp",
     "categories": [
-        "messaging"
+        "utilities"
     ],
     "description": {
         "en": "UnifiedPush distributor for Android with support for a self-hosted Prism server."

--- a/public/data/apps/complex/app.lonecloud.prism.json
+++ b/public/data/apps/complex/app.lonecloud.prism.json
@@ -1,0 +1,18 @@
+{
+    "configs": [
+        {
+            "id": "app.lonecloud.prism",
+            "url": "https://git.lonecloud.dev/lone-cloud/prism-android",
+            "author": "lone-cloud",
+            "name": "Prism",
+            "overrideSource": "Forgejo (Codeberg)"
+        }
+    ],
+    "icon": "https://git.lonecloud.dev/lone-cloud/prism-android/raw/branch/main/assets/prism.webp",
+    "categories": [
+        "messaging"
+    ],
+    "description": {
+        "en": "UnifiedPush distributor for Android with support for a self-hosted Prism server."
+    }
+}


### PR DESCRIPTION
Adds [Prism](https://git.lonecloud.dev/lone-cloud/prism-android), a UnifiedPush distributor for Android with support for a self-hosted Prism server.

- Official source: https://git.lonecloud.dev/lone-cloud/prism-android (self-hosted Forgejo)
- Obtanium requires `overrideSource: "Forgejo (Codeberg)`  to work with self-hosted Forgejo instances
- Package: `app.lonecloud.prism`

This app is already distributed on F-Droid and IzzyOnDroid. Adding it here makes it discoverable for Obtanium users.