### PR TITLE
Add Arkikeskus Launcher

### DIFF
--- a/public/data/apps/simple/org.arkikeskus.launcher.json
+++ b/public/data/apps/simple/org.arkikeskus.launcher.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "id": "org.arkikeskus.launcher",
+        "url": "https://github.com/jrs8205/arkikeskus-launcher",
+        "author": "jrs8205",
+        "name": "Arkikeskus Launcher"
+    },
+    "icon": "https://github.com/jrs8205/arkikeskus-launcher/raw/main/docs/icon.png",
+    "categories": ["launcher_and_desktop"],
+    "description": {
+        "en": "A modern, customizable open-source home-screen launcher built with Jetpack Compose."
+    }
+}


### PR DESCRIPTION
Adds a config for **Arkikeskus Launcher** — a free, open-source Android home-screen launcher built with Jetpack Compose.

- Official source: https://github.com/jrs8205/arkikeskus-launcher
- Signed APKs are attached to every GitHub release (asset `arkikeskus-launcher-<version>.apk`); the versionCode increments each release, so the default GitHub source config works with no extra settings.
- License: Apache-2.0. Original app (not a fork or re-upload) — own package name `org.arkikeskus.launcher` and display name.

Checked against APP_CRITERIA.md: official source (not a re-upload site), not already listed, and not previously requested.
