### PR TITLE
Add Prism Plural

### DIFF
--- a/public/data/apps/complex/com.prismplural.prism.json
+++ b/public/data/apps/complex/com.prismplural.prism.json
@@ -1,0 +1,20 @@
+{
+    "configs": [
+        {
+            "id": "com.prismplural.prism",
+            "url": "https://prismplural.com/download/",
+            "author": "Prism Plural",
+            "name": "Prism",
+            "additionalSettings": "{\"intermediateLink\":[],\"customLinkFilterRegex\":\"/download/android-latest\\\\.apk$\",\"filterByLinkText\":false,\"skipSort\":false,\"reverseSort\":false,\"sortByLastLinkSegment\":false,\"versionExtractWholePage\":true,\"defaultPseudoVersioningMethod\":\"partialAPKHash\",\"trackOnly\":false,\"versionExtractionRegEx\":\"name=\\\"prism:android-version\\\" content=\\\"([^\\\"]+)\\\"\",\"matchGroupToUse\":\"1\",\"versionDetection\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"Prism\",\"appAuthor\":\"Prism Plural\",\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"Private, encrypted app for plural systems.\",\"refreshBeforeDownload\":true,\"supportFixedAPKURL\":true}",
+            "overrideSource": "HTML"
+        }
+    ],
+    "icon": "https://raw.githubusercontent.com/prismplural/prism-app/main/packaging/linux/icons/hicolor/512x512/apps/com.prismplural.prism.png",
+    "categories": [
+        "utilities",
+        "notes"
+    ],
+    "description": {
+        "en": "Prism is a private, encrypted app for plural systems."
+    }
+}


### PR DESCRIPTION
Adds Prism Plural (`com.prismplural.prism`) using the official Prism download page as an HTML source.

Links:
- Website/download page: https://prismplural.com/download/
- GitHub repo: https://github.com/prismplural/prism-app
- GitHub releases: https://github.com/prismplural/prism-app/releases

Package: `com.prismplural.prism`

Notes:
- Uses `/download/android-latest.apk` as the stable APK link.
- Extracts the app version from `<meta name="prism:android-version" ...>`.
- Displays as `Prism` by `Prism Plural` in Obtainium.
- This is distinct from #1512, which is `app.lonecloud.prism` for a UnifiedPush distributor.

Validation:
- Parsed the config JSON and nested `additionalSettings` JSON.
- Live scrape selected `https://prismplural.com/download/android-latest.apk` and extracted `0.14.0+14001`.
- Imported into Obtainium v1.5.2 on an Android API 35 emulator.
- Obtainium displayed `Prism / By Prism Plural`.
- Install resolved and installed `versionCode=14001`, `versionName=0.14.0`.
