### PR TITLE
Bump Geogebra version

### DIFF
--- a/public/data/apps/complex/org.geogebra.android.calculator.suite.json
+++ b/public/data/apps/complex/org.geogebra.android.calculator.suite.json
@@ -2,12 +2,12 @@
     "configs": [
         {
             "id": "org.geogebra.android.calculator.suite",
-            "url": "https://download.geogebra.org/installers/5.2/",
+            "url": "https://download.geogebra.org/installers/5.4/",
             "author": "GeoGebra",
             "name": "GeoGebra Calculator Suite",
             "preferredApkIndex": 0,
             "additionalSettings": "{\"versionExtractionRegEx\":\"[0-9]+-[0-9]+-[0-9]+-[0-9]+\",\"apkFilterRegEx\":\"\\\\bCalculator\",\"about\":\"GeoGebra is more than a set of free tools to do math. It’s a platform to connect enthusiastic teachers and students and offer them a new way to explore and learn about math.\"}",
-            "altLabel": "5.2"
+            "altLabel": "5.4"
         }
     ],
     "icon": "https://play-lh.googleusercontent.com/S-49nyPsFvwd2Q52W9-RNnQbDyKd58VKzaRDIc6vvS2QKvmYlyBZxurt6tNoMX4RFN4u=w480-h960",


### PR DESCRIPTION
5.2 is no longer available. New versions are all 5.4.x. Update accordingly.