### PR TITLE
Add OpenHearing (app.openhearing)

### DIFF
--- a/public/data/apps/complex/app.openhearing.json
+++ b/public/data/apps/complex/app.openhearing.json
@@ -1,0 +1,18 @@
+{
+  "configs": [
+    {
+      "id": "app.openhearing",
+      "url": "https://github.com/HMAKT99/OpenHearing",
+      "author": "HMAKT99",
+      "name": "OpenHearing",
+      "additionalSettings": "{\"includePrereleases\":true}"
+    }
+  ],
+  "icon": null,
+  "categories": [
+    "sports_and_health"
+  ],
+  "description": {
+    "en": "Hearing check, personal per-ear sound profile, and real-time amplification of quiet sound on any earbuds. No internet permission."
+  }
+}

--- a/public/data/apps/complex/app.openhearing.json
+++ b/public/data/apps/complex/app.openhearing.json
@@ -8,7 +8,7 @@
       "additionalSettings": "{\"includePrereleases\":true}"
     }
   ],
-  "icon": null,
+  "icon": "https://raw.githubusercontent.com/HMAKT99/OpenHearing/main/fastlane/metadata/android/en-US/images/icon.png",
   "categories": [
     "sports_and_health"
   ],


### PR DESCRIPTION
Adds a config for [OpenHearing](https://github.com/HMAKT99/OpenHearing) — an open-source (GPL-3.0) hearing-assistance app: pure-tone hearing check → personal per-ear sound profile → real-time amplification of quiet sound on any earbuds. No INTERNET permission.

- Official source: I'm the app's author; signed APKs are published on the repo's GitHub Releases.
- `includePrereleases` is enabled because all releases so far are marked pre-release (the app is in alpha) — without it Obtainium finds no installable release.
- Not a fork; not already on the site (searched the apps list plus open and closed issues/PRs — no existing entry or request).
- Icon is null for now (the launcher icon is an adaptive vector; no hosted PNG yet).