### PR TITLE
Add FitBuddy (com.anant.fitbuddy)

### DIFF
--- a/data/apps/com.anant.fitbuddy.json
+++ b/data/apps/com.anant.fitbuddy.json
@@ -1,0 +1,15 @@
+{
+    "configs": [
+        {
+            "id": "com.anant.fitbuddy",
+            "url": "https://github.com/anantdark/FitBuddy",
+            "author": "anantdark",
+            "name": "FitBuddy",
+            "additionalSettings": "{\"apkFilterRegEx\":\"FitBuddy-[0-9]+\\\\.[0-9]+\\\\.[0-9]+\\\\.apk$\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":false,\"about\":\"AI-powered calorie and workout tracker for Indian diets. Log meals and workouts by photo or text; an LLM estimates calories and macros.\"}"
+        }
+    ],
+    "icon": "https://raw.githubusercontent.com/anantdark/FitBuddy/main/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+    "description": {
+        "en": "AI-powered calorie & workout tracker for Indian diets. Log meals and workouts by photo or text; an LLM estimates calories and macros. Features editable meal review, reusable presets, dashboards, progress charts, and Material You theming. AI provider configured at runtime — no proprietary SDK bundled."
+    }
+}


### PR DESCRIPTION
Adds config for FitBuddy, an AI-powered calorie & workout tracker for Indian diets.

- **Package:** `com.anant.fitbuddy`
- **Source:** https://github.com/anantdark/FitBuddy
- **License:** GPL-3.0-only
- **APK source:** GitHub Releases (official, developer-signed)
- **APK filter:** `FitBuddy-[0-9]+\.[0-9]+\.[0-9]+\.apk$` — matches versioned APK, excludes `-latest.apk` alias and `.aab` bundle

**Checklist:**
- [x] Not already on the config site
- [x] Not already requested in open/closed issues
- [x] Not a fork (original app, unique package name)
- [x] Official source only (GitHub Releases from the app's own repo)