### PR TITLE
Add Meshtastic (com.geeksville.mesh)

### DIFF
--- a/public/data/apps/complex/com.geeksville.mesh.json
+++ b/public/data/apps/complex/com.geeksville.mesh.json
@@ -1,0 +1,27 @@
+{
+    "configs": [
+        {
+            "id": "com.geeksville.mesh",
+            "url": "https://github.com/meshtastic/Meshtastic-Android",
+            "author": "meshtastic",
+            "name": "Meshtastic",
+            "additionalSettings": "{\"apkFilterRegEx\":\"google-release\\\\.apk$\"}",
+            "altLabel": "google (FCM, Maps)"
+        },
+        {
+            "id": "com.geeksville.mesh",
+            "url": "https://github.com/meshtastic/Meshtastic-Android",
+            "author": "meshtastic",
+            "name": "Meshtastic",
+            "additionalSettings": "{\"apkFilterRegEx\":\"fdroid-.*-release\\\\.apk$\",\"autoApkFilterByArch\":true}",
+            "altLabel": "fdroid (no Google services)"
+        }
+    ],
+    "icon": "https://github.com/meshtastic/Meshtastic-Android/raw/main/fastlane/metadata/android/en-US/images/icon.png",
+    "categories": [
+        "messaging"
+    ],
+    "description": {
+        "en": "The official app for Meshtastic, an open-source, off-grid, mesh radio."
+    }
+}


### PR DESCRIPTION
Adds a config for [Meshtastic](https://github.com/meshtastic/Meshtastic-Android), the official Android app for the open-source Meshtastic off-grid mesh radio project. I'm a maintainer of that app.

Source is the project's own GitHub releases — not a fork, mod, or reupload mirror.

### Why two configs

Each release attaches a `google` flavor APK and several `fdroid` flavor ABI splits. Both are the official app and share the **same** signing key, so users can move between them without an uninstall — but they also share the `com.geeksville.mesh` package name, so a config has to pin one flavor or Obtainium is left choosing between them. Hence one alt config per flavor:

- `google (FCM, Maps)` — includes Google Play services (FCM analytics and crashlytics, Google Maps)
- `fdroid (no Google services)` — no Google dependencies

Only the stable channel is here. The app also publishes beta and snapshot prereleases, but per the app criteria I've kept the number of alternatives to a minimum and left the long-term-stable ones only.

### Settings

Everything is left at its default except what's genuinely needed:

- `apkFilterRegEx` — selects one flavor, since both share a package name.
- `autoApkFilterByArch: true` on the fdroid config — this is already the form default, but `appJSONCompatibilityModifiers` coerces the key to `false` when it's absent from a config, and an unset `preferredApkIndex` becomes `0`, so without it the arch splits could resolve to whichever one happens to sort first. Set explicitly so the fdroid filter can match every split and let the arch filter choose.

Deliberately **not** setting `versionExtractionRegEx`: the app's `versionName` is `X.Y.Z (versionCode) <flavor>`, which can't be reconciled against the `vX.Y.Z` tag, so Obtainium falls back to a pseudo-version. That's harmless (tag-to-tag comparison still detects updates), and trimming the tag doesn't help because it only rewrites the release-side version, never the installed `versionName`.

### Testing

- `npm i && npm run dev` — entry loads and renders; `/api/apps?q=meshtastic` returns it as `type: complex` with both configs, correct category, description and icon.
- `npm run build` — passes.
- `node scripts/validate_icons.js --dry-run` — icon passes (512×512 PNG, HTTP 200); not among the files it would null out.
- Both configs installed for real via Obtainium 1.6.10 on an Android 16 device. The google config resolved `androidApp-google-release.apk` and the fdroid config resolved `androidApp-fdroid-arm64-v8a-release.apk` via the arch filter; the installed APK was byte-identical to the release asset, and the app launches.

Happy to adjust the labels or drop one of the two configs if you'd rather have a single entry.