### PR TITLE
Add Kalance

### DIFF
--- a/public/data/apps/simple/app.kalance.android.json
+++ b/public/data/apps/simple/app.kalance.android.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "id": "app.kalance.android",
+    "url": "https://github.com/kattulus1997/kalance-android",
+    "author": "Kalance",
+    "name": "Kalance"
+  },
+  "icon": "https://kalance.app/apple-touch-icon.png",
+  "categories": [
+    "sports_and_health"
+  ],
+  "description": {
+    "en": "A private calorie and macro diary with barcode scanning, food history, goals, and a free plan without ads.",
+    "es": "Diario privado de calorías y macros con escáner de códigos, historial, objetivos y un plan gratuito sin anuncios."
+  }
+}


### PR DESCRIPTION
Adds the official Kalance Android source so Obtainium users can install and follow releases directly from GitHub.

- Package: `app.kalance.android`
- Official source: https://github.com/kattulus1997/kalance-android
- Latest release: `v1.3.0` with a signed APK asset
- Category: Sports & Health
- English and Spanish descriptions

Validation: `npm run build` and the repository icon validator completed successfully.