### PR TITLE
Add CountAway

### DIFF
--- a/public/data/apps/simple/com.santiagorodriguez.countaway.json
+++ b/public/data/apps/simple/com.santiagorodriguez.countaway.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "id": "com.santiagorodriguez.countaway",
+    "url": "https://github.com/santirodriguez/CountAway",
+    "author": "Santiago Rodriguez",
+    "name": "CountAway"
+  },
+  "icon": "https://raw.githubusercontent.com/santirodriguez/CountAway/main/docs/assets/branding/countaway.webp",
+  "categories": [
+    "clock_and_time"
+  ],
+  "description": {
+    "en": "A lightweight Android countdown app with home-screen widgets, local notifications, and no ads, accounts, analytics, or Internet permission.",
+    "es": "Una app ligera de cuenta regresiva para Android con widgets de pantalla de inicio y notificaciones locales, sin anuncios, cuentas, analíticas ni permiso de Internet."
+  }
+}


### PR DESCRIPTION
Adds the official CountAway Android source so Obtainium users can install and track releases directly from GitHub.

* Package: `com.santiagorodriguez.countaway`
* Official source: `https://github.com/santirodriguez/CountAway`
* Category: Clock & Time
* Configuration: default GitHub source; no custom Obtainium settings required
* Includes the official app icon and English/Spanish descriptions

CountAway is a lightweight Android countdown app with home-screen widgets and local notifications. It has no ads, accounts, analytics, or Internet permission.

I am the developer and maintainer of CountAway.