### PR TITLE
Add Expanda

### DIFF
--- a/public/data/apps/simple/dev.diego.expanda.json
+++ b/public/data/apps/simple/dev.diego.expanda.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "id": "dev.diego.expanda",
+    "url": "https://github.com/diegomarzaa/expanda",
+    "author": "diegomarzaa",
+    "name": "Expanda"
+  },
+  "icon": "https://raw.githubusercontent.com/diegomarzaa/expanda/main/docs/expanda-readme-icon.png",
+  "categories": [
+    "utilities"
+  ],
+  "description": {
+    "en": "Offline, open-source text expansion for Android with reusable snippets and dynamic templates."
+  }
+}


### PR DESCRIPTION
Adds Expanda, an offline open-source text expander for Android.

The configuration uses the official GitHub repository and its signed release APK with default GitHub source settings.

- Package ID: `dev.diego.expanda`
- Source and releases: https://github.com/diegomarzaa/expanda
- License: MIT