### PR TITLE
Add OpenTasker

### DIFF
--- a/public/data/apps/simple/com.opentasker.app.json
+++ b/public/data/apps/simple/com.opentasker.app.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "id": "com.opentasker.app",
+    "url": "https://github.com/SysAdminDoc/OpenTasker",
+    "author": "SysAdminDoc",
+    "name": "OpenTasker"
+  },
+  "icon": "https://raw.githubusercontent.com/SysAdminDoc/OpenTasker/master/fastlane/metadata/android/en-US/images/icon.png",
+  "categories": [
+    "automation"
+  ],
+  "description": {
+    "en": "An on-device Tasker alternative. Profiles watch device contexts such as time, location, network, battery, NFC and calendar, then run tasks built from the action catalog. No account, no telemetry and no Play Services."
+  }
+}


### PR DESCRIPTION
Adds a simple config for [OpenTasker](https://github.com/SysAdminDoc/OpenTasker), an on-device automation app for Android in the spirit of Tasker.

- Package: `com.opentasker.app`
- Source: GitHub releases from the official repo, default settings, no `additionalSettings` needed
- Category: automation
- MIT licensed, no ads, no telemetry, no account, no Play Services dependency

Not a fork of another app, and the only download source is the project's own GitHub releases. It isn't on F-Droid or IzzyOnDroid yet, which is why the GitHub source is the one being added.

Latest release is v0.2.87. I checked open and closed issues and PRs for an existing OpenTasker request and found none.
