### PR TITLE
Update Kalance repository owner

### DIFF
--- a/public/data/apps/simple/app.kalance.android.json
+++ b/public/data/apps/simple/app.kalance.android.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "id": "app.kalance.android",
-    "url": "https://github.com/kattulus1997/kalance-android",
+    "url": "https://github.com/GuilleZubikarai/kalance-android",
     "author": "Kalance",
     "name": "Kalance"
   },


### PR DESCRIPTION
The Kalance repository moved to the owner's new GitHub username. This updates the Obtainium source URL so future release checks use the canonical repository.