### PR TITLE
Add OpenDocument Reader

### DIFF
--- a/public/data/apps/simple/at.tomtasche.reader.foss.json
+++ b/public/data/apps/simple/at.tomtasche.reader.foss.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "id": "at.tomtasche.reader.foss",
+    "url": "https://github.com/opendocument-app/OpenDocument.droid",
+    "author": "opendocument-app",
+    "name": "OpenDocument Reader"
+  },
+  "icon": "https://opendocument.app/icon-512.png",
+  "categories": [
+    "document_and_pdf_viewer"
+  ],
+  "description": {
+    "en": "Views and edits ODT, ODS, ODP, DOCX, XLSX, PPTX and PDF entirely on the device: offline, without an account, without uploading anything."
+  }
+}


### PR DESCRIPTION
Adds a config for **OpenDocument Reader**, an OpenDocument and Office file viewer and editor for Android, shipping since 2010. First-party submission — we publish the app and maintain the releases this points at.

- **Package ID:** `at.tomtasche.reader.foss`
- **Source:** https://github.com/opendocument-app/OpenDocument.droid — our own repository
- **APK:** https://github.com/opendocument-app/OpenDocument.droid/releases/latest
- **Category:** `document_and_pdf_viewer`
- **License:** MPL-2.0

`simple/`, because nothing is moved off its default. Each release carries exactly one universal APK, `app-foss-release.apk`, beside a `version.json` that is not an APK and is ignored, so the default asset matching finds it without a filter. Tags are `vX.Y.Z`, and only stable releases are ever published — v4.16.0, v4.17.0 and v4.18.0 all have that shape.

The package id is the FOSS build's. The Play builds are `at.tomtasche.reader` (free) and `at.tomtasche.reader.pro` (paid), and F-Droid ships `at.tomtasche.reader`; the same app carries a different application id per channel so a sideload can sit beside a store install. The FOSS build is the one that links no proprietary library, which is why it is the one on the GitHub release.

Description in English only for now, rather than fifteen lifted from a store listing whose tone is not consistent across them. Icon is our own, served from opendocument.app.

### App criteria

- Not on the config website today.
- Searched open **and** closed issues and PRs — no prior request or attempt for this app.
- Not a fork — original app, original package name and display name.
- Official source only: our own GitHub releases, not a reupload site.

Built locally with `npm run build`; the entry renders.