### PR TITLE
Add spoo.me (me.spoo.android)

### DIFF
--- a/public/data/apps/simple/me.spoo.android.json
+++ b/public/data/apps/simple/me.spoo.android.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "id": "me.spoo.android",
+    "url": "https://github.com/spoo-me/spoo-android",
+    "author": "spoo.me",
+    "name": "spoo.me"
+  },
+  "icon": "https://raw.githubusercontent.com/spoo-me/spoo-android/main/.github/assets/icon.png",
+  "categories": [
+    "url_manipulation"
+  ],
+  "description": {
+    "en": "Shorten, manage, and analyze your spoo.me links. Material 3 Expressive, with build-your-own chart widgets and emoji aliases."
+  }
+}


### PR DESCRIPTION
Adds spoo.me, the official Android client for the spoo.me URL shortener.

- Official source only: APKs are signed and published from CI to GitHub releases, works with the default GitHub source and default settings (simple config)
- FOSS (AGPL-3.0), no ads, no trackers
- Not a fork, not already listed, no existing request found in open or closed issues
- Icon served from the app repository, category url_manipulation