### PR TITLE
Add Driver Driver

### DIFF
--- a/public/data/apps/simple/com.ubercharged.driverdriver.json
+++ b/public/data/apps/simple/com.ubercharged.driverdriver.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "id": "com.ubercharged.driverdriver",
+    "url": "https://github.com/chosen-man/driver-driver",
+    "author": "chosen-man",
+    "name": "Driver Driver"
+  },
+  "categories": [
+    "downloader_and_manager",
+    "utilities"
+  ],
+  "description": {
+    "en": "Find and download emulator graphics-driver packages from public GitHub releases, with recommendations based on your Android device's GPU."
+  }
+}


### PR DESCRIPTION
## Summary

Adds Driver Driver, an Android utility for finding and downloading emulator graphics-driver packages from public GitHub releases. The entry uses the official repository and default GitHub source settings.

## Verification

- Confirmed package ID: com.ubercharged.driverdriver
- Confirmed the official latest GitHub release provides an APK
- Confirmed there are no existing open or closed issues or pull requests for Driver Driver
- JSON parsing passes
- Astro production build passes

The repository typecheck also runs but currently reports pre-existing errors in src/layouts/Layout.astro related to the Plausible analytics snippet.