### PR TITLE
Add Liseur

### DIFF
--- a/public/data/apps/simple/com.chmouel.liseur.json
+++ b/public/data/apps/simple/com.chmouel.liseur.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "id": "com.chmouel.liseur",
+        "url": "https://github.com/chmouel/liseur",
+        "author": "Chmouel Boudjnah",
+        "name": "Liseur"
+    },
+    "icon": "https://raw.githubusercontent.com/chmouel/liseur/main/fastlane/metadata/android/en-US/images/icon.png",
+    "categories": [
+        "document_and_pdf_viewer"
+    ],
+    "description": {
+        "en": "An open-source EPUB reader for Android with calibre-web, Komga, liseur-sync, and OPDS sync support."
+    }
+}


### PR DESCRIPTION
Adds a simple config for [Liseur](https://github.com/chmouel/liseur), an open-source EPUB reader for Android with calibre-web, Komga, liseur-sync, and OPDS sync support.

This is a first-party submission. I am the author and maintainer of Liseur and its releases.

Against the app criteria:

- **Official source.** The config points at the official GitHub repo, which is where every signed build is published. No reupload site is involved.
- **Not a fork.** Liseur is an original app.
- **Not previously requested.** I searched open and closed issues and pull requests and found no existing request or config for it.
- **Defaults only.** A plain GitHub source with no `additionalSettings`, so it goes in `simple/`. Each release publishes exactly one APK, so default asset matching works without a filter.

Liseur is also available on [F-Droid](https://f-droid.org/en/packages/com.chmouel.liseur/).