### PR TITLE
Add Video Boost AO

### DIFF
--- a/public/data/apps/simple/com.agustin.videoboostao.json
+++ b/public/data/apps/simple/com.agustin.videoboostao.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "id": "com.agustin.videoboostao",
+    "url": "https://github.com/AgusRomeroL/video-boost-ao",
+    "author": "AgusRomeroL",
+    "name": "Video Boost AO"
+  },
+  "icon": "https://raw.githubusercontent.com/AgusRomeroL/video-boost-ao/main/fastlane/metadata/android/en-US/images/icon.png",
+  "categories": [
+    "camera",
+    "automation"
+  ],
+  "description": {
+    "en": "Pixel Camera turns Video Boost off every time you close it. This app re-enables it automatically each time you open the camera in video mode, without root. For Pixel 8 Pro and newer.",
+    "es": "La cámara del Pixel apaga el Video mejorado cada vez que la cierras. Esta app lo reactiva automáticamente al abrir la cámara en modo video, sin root. Para Pixel 8 Pro y posteriores."
+  }
+}


### PR DESCRIPTION
Adds a config for **Video Boost AO** (`com.agustin.videoboostao`), a free and open source app (MIT) that keeps Video Boost enabled on Pixel Pro cameras without root.

Pixel Camera turns Video Boost off every time the app is closed, and there is no setting that pins it. The app re-enables it automatically each time the camera opens in video mode.

Against the app criteria:

- Official source: the repo belongs to the app author, and the APK is published as a GitHub release asset, so no reupload site is involved.
- Not a fork.
- Not already listed, and I found no existing request for it in open or closed issues.
- Works with default settings, so it goes in `simple/`. Release tags are `vX.Y` and each release carries a single signed APK asset.

Icon and localized descriptions are included. Latest release: https://github.com/AgusRomeroL/video-boost-ao/releases/latest