### PR TITLE
feat(apps): Add Candy Browser

### DIFF
--- a/public/data/apps/complex/dev.sk2andy.materialbrowser.json
+++ b/public/data/apps/complex/dev.sk2andy.materialbrowser.json
@@ -1,0 +1,26 @@
+{
+  "configs": [
+    {
+      "id": "dev.sk2andy.materialbrowser",
+      "url": "https://github.com/sk2andy/candy-browser",
+      "author": "sk2andy",
+      "name": "Candy Browser",
+      "additionalSettings": "{\"apkFilterRegEx\":\"^CandyBrowser-v[0-9]+(?:\\\\.[0-9]+){1,2}-release\\\\.apk$\"}",
+      "altLabel": "Standard (recommended)"
+    },
+    {
+      "id": "dev.sk2andy.materialbrowser",
+      "url": "https://github.com/sk2andy/candy-browser",
+      "author": "sk2andy",
+      "name": "Candy Browser User CA",
+      "additionalSettings": "{\"apkFilterRegEx\":\"^CandyBrowser-v[0-9]+(?:\\\\.[0-9]+){1,2}-user-ca-release\\\\.apk$\"}",
+      "altLabel": "User CA (advanced)"
+    }
+  ],
+  "icon": "https://raw.githubusercontent.com/sk2andy/candy-browser/main/app/src/main/res/drawable-nodpi/ic_launcher_foreground_art.png",
+  "categories": ["browser"],
+  "description": {
+    "en": "A privacy-focused Android browser with local content blocking and private browsing.",
+    "de": "Ein datenschutzorientierter Android-Browser mit lokaler Inhaltsblockierung und privatem Surfen."
+  }
+}


### PR DESCRIPTION
Add Candy Browser from its official GitHub release source.

Candy Browser publishes standard and User CA APKs under the same package ID and signing key. Two labeled configs are needed so users can deliberately choose one channel, while strict asset filters prevent Obtainium from selecting checksum files or the other APK variant.

The standard channel is marked as recommended. The User CA channel is labeled advanced because it changes the browser trust model.

Repository pre-commit checks and the Astro production build pass. The Candy icon URL was accepted by the repository validator.