### PR TITLE
Add Punktfunk

### DIFF
--- a/public/data/apps/complex/io.unom.punktfunk.json
+++ b/public/data/apps/complex/io.unom.punktfunk.json
@@ -1,0 +1,19 @@
+{
+    "configs": [
+        {
+            "id": "io.unom.punktfunk",
+            "url": "https://git.unom.io/unom/punktfunk/releases",
+            "author": "unom",
+            "name": "Punktfunk",
+            "additionalSettings": "{\"intermediateLink\":[],\"customLinkFilterRegex\":\"punktfunk-[0-9]+(?:\\\\.[0-9]+)+\\\\.apk$\",\"filterByLinkText\":false,\"matchLinksOutsideATags\":false,\"skipSort\":false,\"reverseSort\":false,\"sortByLastLinkSegment\":false,\"versionExtractWholePage\":false,\"requestHeader\":[{\"requestHeader\":\"User-Agent: Obtainium/1.0\"}],\"defaultPseudoVersioningMethod\":\"APKLinkHash\",\"trackOnly\":false,\"versionExtractionRegEx\":\"punktfunk-([0-9]+(?:\\\\.[0-9]+)+)\\\\.apk$\",\"matchGroupToUse\":\"$1\",\"versionDetection\":true,\"releaseDateAsVersion\":false,\"useVersionCodeAsOSVersion\":false,\"apkFilterRegEx\":\"\",\"invertAPKFilter\":false,\"autoApkFilterByArch\":true,\"appName\":\"Punktfunk\",\"appAuthor\":\"unom\",\"shizukuPretendToBeGooglePlay\":false,\"allowInsecure\":false,\"exemptFromBackgroundUpdates\":false,\"skipUpdateNotifications\":false,\"about\":\"Next-generation game streaming client\",\"refreshBeforeDownload\":false,\"includeZips\":false,\"zippedApkFilterRegEx\":\"\"}",
+            "overrideSource": "HTML"
+        }
+    ],
+    "icon": "https://git.unom.io/unom/punktfunk/raw/branch/main/docs-site/public/favicon.svg",
+    "categories": [
+        "other"
+    ],
+    "description": {
+        "en": "Next-generation game streaming client"
+    }
+}     

--- a/public/data/apps/complex/io.unom.punktfunk.json
+++ b/public/data/apps/complex/io.unom.punktfunk.json
@@ -16,4 +16,4 @@
     "description": {
         "en": "Next-generation game streaming client"
     }
-}     
+}


### PR DESCRIPTION
Adds a config for Punktfunk (io.unom.punktfunk), a free and open source app (MIT) that allows you to stream from Linux and Windows PC's to different clients.

Against the app criteria:

- Official source: the repo belongs to the app author, and the APK is published on the author's personal Gitea instance as a release asset, so no reupload site is involved.
- Not a fork.
- Not already listed, and I found no existing request for it in open or closed issues.
- Release tags are vX.Y and each release carries a single signed APK asset. Icon and localized descriptions are included. Latest release: https://git.unom.io/unom/punktfunk/releases