### PR TITLE
Add Neutron Code Limited app suite

### DIFF
--- a/public/data/apps/complex/com.neutroncode.mp.json
+++ b/public/data/apps/complex/com.neutroncode.mp.json
@@ -1,0 +1,95 @@
+{
+    "configs": [
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/2-neutronmpapkarm64",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARM64 (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/4-neutronmpapkarm64-usb-no-def",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARM64, no USB DAC (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/6-neutronmpapkx64",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "x64 (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/5-neutronmpapk",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARMv7 (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/8-neutronmpapkneon",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARMv7+NEON (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/2-neutronmpapkarm64",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARMv7+NEON, no USB DAC (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/12-neutronmpapkx86",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "x86+SSE2 (generic)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/3-neutronmpapkarm64-googleplay",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARM64 (GPlay)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/7-neutronmpapk-googleplay",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARMv7 (GPlay)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/10-neutronmpapkneon-googleplay",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "ARMv7+NEON (GPlay)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/14-neutronmpapkx86-googleplay",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "x86+SSE2 (GPlay)"
+        },
+        {
+            "id": "com.neutroncode.mp",
+            "url": "https://neutroncode.com/downloads/file/15-neutronmpapkx64-googleplay",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Music Player",
+            "altLabel": "x64 (GPlay)"
+        }
+    ],
+    "icon": "https://play-lh.googleusercontent.com/H_Lz_YCPVRqwtA9yCdO5tZW9wZcvW0gTA552vUZSS8LpNPWTeXG1U0PPJpyyGCrRpDaQWxIcXU-NLyAJDpNFLg=s0?imgmax=0",
+    "categories": [
+        "music"
+    ],
+    "description": {
+        "en": "Audiophile music player with advanced DSP"
+    }
+}

--- a/public/data/apps/complex/com.neutroncode.rc.json
+++ b/public/data/apps/complex/com.neutroncode.rc.json
@@ -1,0 +1,39 @@
+{
+    "configs": [
+        {
+            "id": "com.neutroncode.rc",
+            "url": "https://neutroncode.com/downloads/file/1-neutronrcapkarm64",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Audio Recorder",
+            "altLabel": "ARM64 (generic)"
+        },
+        {
+            "id": "com.neutroncode.rc",
+            "url": "https://neutroncode.com/downloads/file/9-neutronrcapkx86",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Audio Recorder",
+            "altLabel": "x86 + SSE (generic)"
+        },
+        {
+            "id": "com.neutroncode.rc",
+            "url": "https://neutroncode.com/downloads/file/13-neutronrcapkneon",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Audio Recorder",
+            "altLabel": "ARMv7 + NEON (generic)"
+        },
+        {
+            "id": "com.neutroncode.rc",
+            "url": "https://neutroncode.com/downloads/file/18-neutronrcapkx64",
+            "author": "Neutron Code Limited",
+            "name": "Neutron Audio Recorder",
+            "altLabel": "x64 (generic)"
+        }
+    ],
+    "icon": "https://play-lh.googleusercontent.com/0xpJN0FqtiH32nupFeFjS7M4JbH-llfjHgxs4Y582MrQs6laswL-aLZaZc1VUUBfIU8vfVug3K-mGyWOZYnufA=s0?imgmax=0",
+    "categories": [
+        "recorder"
+    ],
+    "description": {
+        "en": "Professional audio recording with DSP"
+    }
+}


### PR DESCRIPTION
Downloads: <https://neutroncode.com/downloads>
NConfigurator (outside of desktop apps) isn't available to download there, only on Play Store: <https://play.google.com/store/apps/details?id=com.neutroncode.nconf>