### PR TITLE
Add Anvil (io.github.j3r0nim0.anvil)

### DIFF
--- a/public/data/apps/simple/io.github.j3r0nim0.anvil.json
+++ b/public/data/apps/simple/io.github.j3r0nim0.anvil.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "id": "io.github.j3r0nim0.anvil",
+    "url": "https://github.com/j3r0nim0/android-xmrig-monero",
+    "author": "j3r0nim0",
+    "name": "Anvil"
+  },
+  "icon": "https://raw.githubusercontent.com/j3r0nim0/android-xmrig-monero/master/docs/icon.png",
+  "categories": [
+    "finance",
+    "utilities"
+  ],
+  "description": {
+    "en": "Open-source Android host for XMRig (MoneroOcean). Paste a wallet, start mining. 0% cut. ARM64, Android 8+."
+  }
+}


### PR DESCRIPTION
Adds a simple GitHub config for [Anvil](https://github.com/j3r0nim0/android-xmrig-monero).

- **Package:** `io.github.j3r0nim0.anvil`
- **Source:** official GitHub Releases (`Anvil-*.apk`)
- **What it is:** open-source ARM64 Android host for the MoneroOcean XMRig binary. Paste a wallet, start mining. 0% app cut.
- Defaults only (no `additionalSettings`). Icon hosted in the upstream repo.

I maintain the app. Happy to change category if `finance`/`utilities` is the wrong bucket.