### PR TITLE
Add Billiards (dev.tailuge.billiards)

### DIFF
--- a/public/data/apps/simple/dev.tailuge.billiards.json
+++ b/public/data/apps/simple/dev.tailuge.billiards.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "id": "dev.tailuge.billiards",
+    "url": "https://github.com/tailuge/wbilliards",
+    "author": "tailuge",
+    "name": "Billiards"
+  },
+  "icon": "https://billiards.tailuge.workers.dev/assets/icon-512.png",
+  "categories": [
+    "games",
+    "sports_and_health"
+  ],
+  "description": {
+    "en": "Free multiplayer lobby for Billiards. Find matches, challenge players, and play realistic pool online. Official Trusted Web Activity wrapper for billiards.tailuge.workers.dev — the app is a thin shell that opens the live game fullscreen."
+  }
+}


### PR DESCRIPTION
APK link: https://github.com/tailuge/wbilliards/releases/latest/download/Billiards.apk
     Source: https://github.com/tailuge/wbilliards (official Trusted Web Activity wrapper,
     maintained by the author of the PWA at https://billiards.tailuge.workers.dev —
     same owner, so this is the official source, not a third-party repackage).

     Tested with Obtainium: app detected from the GitHub source, v1.0.2 installs and
     launches the game fullscreen. Simple config, default settings, stable releases only.
     Searched existing issues/PRs — no prior request for this app.

FOSS billiards simulator