### PR TITLE
feat: add OpenTubeX and OpenTubeX Nightly

### DIFF
--- a/public/data/apps/complex/org.opentubex.app.nightly.json
+++ b/public/data/apps/complex/org.opentubex.app.nightly.json
@@ -5,7 +5,7 @@
             "url": "https://github.com/OpenTubeX/OpenTubeX",
             "author": "OpenTubeX",
             "name": "OpenTubeX Nightly",
-            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"nightly\",\"apkFilterRegEx\":\"android-universal[.]apk$\"}"
+            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"nightly\",\"apkFilterRegEx\":\"android-(arm64-v8a|armeabi-v7a|x86_64|x86|universal)[.]apk$\",\"autoApkFilterByArch\":true}"
         }
     ],
     "icon": "https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/development/_icons/iconColor.png",

--- a/public/data/apps/complex/org.opentubex.app.nightly.json
+++ b/public/data/apps/complex/org.opentubex.app.nightly.json
@@ -8,7 +8,7 @@
             "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"nightly\",\"apkFilterRegEx\":\"android-(arm64-v8a|armeabi-v7a|x86_64|x86|universal)[.]apk$\",\"autoApkFilterByArch\":true}"
         }
     ],
-    "icon": "https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/development/_icons/iconColor.png",
+    "icon": "https://raw.githubusercontent.com/OpenTubeX/fdroid/main/metadata/org.opentubex.app.nightly/en-US/images/icon.png",
     "categories": [
         "video_player",
         "privacy_and_anonymity"

--- a/public/data/apps/complex/org.opentubex.app.nightly.json
+++ b/public/data/apps/complex/org.opentubex.app.nightly.json
@@ -1,0 +1,20 @@
+{
+    "configs": [
+        {
+            "id": "org.opentubex.app.nightly",
+            "url": "https://github.com/OpenTubeX/OpenTubeX",
+            "author": "OpenTubeX",
+            "name": "OpenTubeX Nightly",
+            "additionalSettings": "{\"includePrereleases\":true,\"fallbackToOlderReleases\":true,\"filterReleaseTitlesByRegEx\":\"nightly\",\"apkFilterRegEx\":\"android-universal[.]apk$\"}"
+        }
+    ],
+    "icon": "https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/development/_icons/iconColor.png",
+    "categories": [
+        "video_player",
+        "privacy_and_anonymity"
+    ],
+    "description": {
+        "en": "Nightly development builds of OpenTubeX, an open-source, customizable, privacy-focused YouTube client. Installs alongside OpenTubeX and may be unstable.",
+        "de": "Nächtliche Entwicklungsversionen von OpenTubeX, einem quelloffenen, anpassbaren YouTube-Client mit Fokus auf Datenschutz. Lässt sich parallel zu OpenTubeX installieren und kann instabil sein."
+    }
+}

--- a/public/data/apps/simple/org.opentubex.app.json
+++ b/public/data/apps/simple/org.opentubex.app.json
@@ -1,0 +1,17 @@
+{
+    "config": {
+        "id": "org.opentubex.app",
+        "url": "https://github.com/OpenTubeX/OpenTubeX",
+        "author": "OpenTubeX",
+        "name": "OpenTubeX"
+    },
+    "icon": "https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/development/_icons/iconColor.png",
+    "categories": [
+        "video_player",
+        "privacy_and_anonymity"
+    ],
+    "description": {
+        "en": "An open-source, customizable, privacy-focused YouTube client with subscriptions, playlists, and SponsorBlock. The Android app is currently in alpha.",
+        "de": "Ein quelloffener, anpassbarer YouTube-Client mit Fokus auf Datenschutz, mit Abonnements, Wiedergabelisten und SponsorBlock. Die Android-App befindet sich derzeit in der Alpha-Phase."
+    }
+}

--- a/public/data/apps/simple/org.opentubex.app.json
+++ b/public/data/apps/simple/org.opentubex.app.json
@@ -5,7 +5,7 @@
         "author": "OpenTubeX",
         "name": "OpenTubeX"
     },
-    "icon": "https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/development/_icons/iconColor.png",
+    "icon": "https://raw.githubusercontent.com/OpenTubeX/fdroid/main/metadata/org.opentubex.app/en-US/images/icon.png",
     "categories": [
         "video_player",
         "privacy_and_anonymity"


### PR DESCRIPTION
OpenTubeX and OpenTubeX Nightly are missing from the app directory. Add separate entries for both Android apps using their official GitHub releases.

- OpenTubeX uses a simple config with default settings.
- OpenTubeX Nightly uses the settings published in the project's README to include prereleases, filter for nightly releases and Android APKs, select the device's CPU architecture with a universal fallback, and fall back to an older release when necessary.
- Both entries include the official icon, categories, and English and German descriptions. The descriptions identify the Android alpha status and the nightly development channel.

Validated both entries through the site's data loader and config serializer against published releases `v0.34.1-beta` and `v0.34.0-nightly-1304`. Both channels provide four architecture APKs and a universal APK. Checked the nightly filter accepts those filenames and rejects unrelated files, and verified the icon loads and decodes. Installation in Obtainium has not been tested.

Prepared with GPT-6 in Codex.
