### PR TITLE
Add FixVol - privacy-first volume control for broken buttons

### DIFF
--- a/public/data/apps/simple/com.fixvol.app.json
+++ b/public/data/apps/simple/com.fixvol.app.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "id": "com.fixvol.app",
+    "url": "https://github.com/ziuus/FixVol",
+    "author": "ziuus",
+    "name": "FixVol"
+  },
+  "icon": "https://raw.githubusercontent.com/ziuus/FixVol/master/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+  "categories": [
+    "tools",
+    "accessibility"
+  ],
+  "description": {
+    "en": "The most user-friendly and privacy-respecting volume control for Android devices with broken, unreliable physical volume buttons. Plays audio? FixVol detects it. Android's native volume panel appears. No floating controls, no overlays, no ads, no tracking — 100% offline."
+  }
+}


### PR DESCRIPTION
## Summary
Adds FixVol to the Obtainium crowdsourced app directory.

**FixVol** is a privacy-first Android utility that restores volume control on devices with broken physical buttons. It uses Android's native SystemUI volume panel — no overlays, no floating controls, no ads, no tracking, 100% offline.

- **Package ID**: `com.fixvol.app`
- **Source**: https://github.com/ziuus/FixVol
- **Author**: ziuus
- **Categories**: tools, accessibility

## App Criteria Check
- [x] Official source (owner's own GitHub repo)
- [x] Not a fork
- [x] Not a reupload site
- [x] Active releases (v1.3.0 published)
- [x] Privacy-respecting (no ads, no tracking, offline)

## Testing
- [x] Config validates with Obtainium import format
- [x] GitHub release APK is signed and installable
- [x] Icon URL resolves to a valid PNG

🤖 Generated with [Obtainium Directory PR Bot](https://github.com/ImranR98/apps.obtainium.imranr.dev)