### PR TITLE
Add GrapheneOS apps

### DIFF
--- a/public/data/apps/simple/app.attestation.auditor.json
+++ b/public/data/apps/simple/app.attestation.auditor.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "id": "app.attestation.auditor",
+        "url": "https://github.com/GrapheneOS/Auditor",
+        "author": "GrapheneOS",
+        "name": "Auditor"
+    },
+    "icon": "https://play-lh.googleusercontent.com/pLmKOi--XDjh2zOTfh_eYTNfbsv19xjnG_X2Tm7-jdC2f1w3PRNctoaRLkvrK1lWJfzH3JCRdGFAmvlmhAdJ=s0?imgmax=0",
+    "categories": [
+        "system"
+    ],
+    "description": {
+        "en": "Hardware-based attestation and intrusion detection app for Android."
+    }
+}

--- a/public/data/apps/simple/app.grapheneos.apps.json
+++ b/public/data/apps/simple/app.grapheneos.apps.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "id": "app.grapheneos.apps",
+        "url": "https://github.com/GrapheneOS/AppStore",
+        "author": "GrapheneOS",
+        "name": "App Store"
+    },
+    "icon": "https://avatars.githubusercontent.com/u/48847184",
+    "categories": [
+        "downloader_and_manager"
+    ],
+    "description": {
+        "en": "App Store is the client for the GrapheneOS app repository. It's included in GrapheneOS but can also be used on other Android 12+ operating systems."
+    }
+}

--- a/public/data/apps/simple/app.grapheneos.camera.json
+++ b/public/data/apps/simple/app.grapheneos.camera.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "id": "app.grapheneos.camera",
+        "url": "https://github.com/GrapheneOS/Camera",
+        "author": "GrapheneOS",
+        "name": "Secure Camera"
+    },
+    "icon": "https://play-lh.googleusercontent.com/n5lTDRC7dwZxWsEqL9ej5YhAPc9mPIoxcUAaHU9ihSuF1ROg1oVKf0233UAj-a4CDW9Oy3JpDmHZsAoiz_A0gA=s0?imgmax=0",
+    "categories": [
+        "camera"
+    ],
+    "description": {
+        "en": "Modern camera app focused on privacy and security with QR & barcode scanning."
+    }
+}

--- a/public/data/apps/simple/app.grapheneos.pdfviewer.json
+++ b/public/data/apps/simple/app.grapheneos.pdfviewer.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "id": "app.grapheneos.pdfviewer",
+        "url": "https://github.com/GrapheneOS/PdfViewer",
+        "author": "GrapheneOS",
+        "name": "Secure PDF Viewer"
+    },
+    "icon": "https://play-lh.googleusercontent.com/_PRdL0erTp55d2PE7Og_yWPGBHO78Cl-fZKsLeRJWJ6Tyv82czi-aP9I2Drhpm_MPRd5VAEVBEPU5eW8R7yMWms=s0?imgmax=0",
+    "categories": [
+        "document_and_pdf_viewer"
+    ],
+    "description": {
+        "en": "Simple Android PDF viewer based on pdf.js and content providers."
+    }
+}


### PR DESCRIPTION
Vanadium doesn't work outside GrapheneOS (for now), so not added here.