### PR TITLE
Add QOwnNotes Mobile app config

### DIFF
--- a/public/data/apps/simple/org.qownnotes.mobile.json
+++ b/public/data/apps/simple/org.qownnotes.mobile.json
@@ -1,0 +1,16 @@
+{
+    "config": {
+        "id": "org.qownnotes.mobile",
+        "url": "https://github.com/qownnotes/qownnotes-android",
+        "author": "qownnotes",
+        "name": "QOwnNotes"
+    },
+    "icon": "https://github.com/qownnotes/qownnotes-android/raw/main/fastlane/metadata/android/en-US/images/icon.png",
+    "categories": [
+        "notes",
+        "synchronisation"
+    ],
+    "description": {
+        "en": "Offline Markdown notes synchronized safely with Nextcloud"
+    }
+}


### PR DESCRIPTION
Adds QOwnNotes Mobile to the Obtainium app catalog.

- **Package:** `org.qownnotes.mobile`
- **Source:** [qownnotes/qownnotes-android](https://github.com/qownnotes/qownnotes-android)
- **Categories:** notes, synchronisation
- **Description:** Offline Markdown notes synchronized safely with Nextcloud

The app uses standard GitHub releases with `v*` tags and a single APK asset per release, so no custom `additionalSettings` are needed.